### PR TITLE
refactor : 컨퍼런스 도메인 요구사항에 맞게 변경

### DIFF
--- a/src/main/java/com/synergy/backend/domain/conference/dto/requset/ConferenceCreateRequest.java
+++ b/src/main/java/com/synergy/backend/domain/conference/dto/requset/ConferenceCreateRequest.java
@@ -1,6 +1,7 @@
 package com.synergy.backend.domain.conference.dto.requset;
 
 
+import jakarta.persistence.Column;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 
@@ -14,7 +15,11 @@ public record ConferenceCreateRequest(
         @Future(message = "종료 날짜는 미래여야 합니다.")
         LocalDateTime endDate,
         @NotBlank(message = "컨퍼런스 위치 정보는 필수입니다. 공백 이하는 불가능합니다.")
-        String location
+        String location,
+        @NotBlank(message = "주최자명은 필수입니다. 공백 이하는 불가능합니다.")
+        String organizer,
+        @NotBlank(message = "컨퍼런스 유형은 필수입니다. 공백 이하는 불가능합니다.")
+        String type
 ) {
 }
 

--- a/src/main/java/com/synergy/backend/domain/conference/dto/requset/ConferenceUpdateRequest.java
+++ b/src/main/java/com/synergy/backend/domain/conference/dto/requset/ConferenceUpdateRequest.java
@@ -17,7 +17,9 @@ public record ConferenceUpdateRequest(
     @Future(message = "종료 날짜는 미래여야 합니다.")
     LocalDateTime endTime,
 
-    String location
+    String location,
+    String organizer,
+    String type
 ) {
 }
 

--- a/src/main/java/com/synergy/backend/domain/conference/dto/response/ConferenceUpdateResponse.java
+++ b/src/main/java/com/synergy/backend/domain/conference/dto/response/ConferenceUpdateResponse.java
@@ -9,14 +9,18 @@ public record ConferenceUpdateResponse(
         String name,
         LocalDateTime startTime,
         LocalDateTime endTime,
-        String location
+        String location,
+        String organizer,
+        String type
 ) {
     public static ConferenceUpdateResponse from(Conference conference) {
         TimePeriod period = conference.getPeriod();
         return new ConferenceUpdateResponse(conference.getName(),
                 period.getStartDateTime(),
                 period.getEndDateTime(),
-                conference.getLocation());
+                conference.getLocation(),
+                conference.getOrganizer(),
+                conference.getType());
     }
 
 }

--- a/src/main/java/com/synergy/backend/domain/conference/entity/Conference.java
+++ b/src/main/java/com/synergy/backend/domain/conference/entity/Conference.java
@@ -21,6 +21,7 @@ import static lombok.AccessLevel.PROTECTED;
 public class Conference {
 
     public static final int MAX_NAME_LENGTH = 30;
+    public static final int MAX_ORGANIZER_LENGTH = 10;
     public static final int MAX_COMMON_LENGTH = 50;
     public static final int MAX_LOCATION_LENGTH = 100;
 
@@ -35,7 +36,7 @@ public class Conference {
     @Embedded
     private TimePeriod period;
 
-    @Column(nullable = false, length = MAX_COMMON_LENGTH)
+    @Column(nullable = false, length = MAX_ORGANIZER_LENGTH)
     private String organizer;
 
     @Column(nullable = false, length = MAX_LOCATION_LENGTH)
@@ -63,10 +64,13 @@ public class Conference {
             throw new InvalidNameException();
         }
 
-        if (organizer.length() > MAX_COMMON_LENGTH || organizer.isBlank() || type.length() > MAX_COMMON_LENGTH || type.isBlank()) {
+        if (type.length() > MAX_COMMON_LENGTH || type.isBlank()) {
             throw new InvalidCommonException();
         }
 
+        if (organizer.length() > MAX_ORGANIZER_LENGTH || organizer.isBlank()) {
+            throw new InvalidOrganizerException();
+        }
         if (location.length() > MAX_LOCATION_LENGTH || location.isBlank()) {
             throw new InvalidLocationException();
         }

--- a/src/main/java/com/synergy/backend/domain/conference/entity/Conference.java
+++ b/src/main/java/com/synergy/backend/domain/conference/entity/Conference.java
@@ -84,4 +84,12 @@ public class Conference {
     public void updatePeriod(TimePeriod period) {
         this.period = period;
     }
+
+    public void updateOrganizer(String organizer) {
+        this.organizer = organizer;
+    }
+
+    public void updateType(String type) {
+        this.type = type;
+    }
 }

--- a/src/main/java/com/synergy/backend/domain/conference/entity/Conference.java
+++ b/src/main/java/com/synergy/backend/domain/conference/entity/Conference.java
@@ -20,7 +20,8 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 public class Conference {
 
-    public static final int MAX_NAME_LENGTH = 50;
+    public static final int MAX_NAME_LENGTH = 30;
+    public static final int MAX_COMMON_LENGTH = 50;
     public static final int MAX_LOCATION_LENGTH = 100;
 
     @Id
@@ -34,8 +35,14 @@ public class Conference {
     @Embedded
     private TimePeriod period;
 
+    @Column(nullable = false, length = MAX_COMMON_LENGTH)
+    private String organizer;
+
     @Column(nullable = false, length = MAX_LOCATION_LENGTH)
     private String location;
+
+    @Column(nullable = false, length = MAX_COMMON_LENGTH)
+    private String type;
 
     @OneToMany(mappedBy = "conference", cascade = {CascadeType.PERSIST, REMOVE}, orphanRemoval = true)
     private List<Session> sessions = new ArrayList<>();
@@ -43,30 +50,38 @@ public class Conference {
     @OneToMany(mappedBy = "conference", cascade = {CascadeType.PERSIST, REMOVE}, orphanRemoval = true)
     private List<Booth> booths = new ArrayList<>();
 
-    private Conference(String name, TimePeriod period, String location) {
+    private Conference(String name, TimePeriod period, String organizer, String location, String type) {
         this.name = name;
         this.period = period;
+        this.organizer = organizer;
         this.location = location;
+        this.type = type;
     }
 
-    public static Conference of(String name, TimePeriod period, String location) {
+    public static Conference of(String name, TimePeriod period, String organizer, String location, String type) {
         if (name.length() > MAX_NAME_LENGTH || name.isBlank()) {
             throw new InvalidNameException();
+        }
+
+        if (organizer.length() > MAX_COMMON_LENGTH || organizer.isBlank() || type.length() > MAX_COMMON_LENGTH || type.isBlank()) {
+            throw new InvalidCommonException();
         }
 
         if (location.length() > MAX_LOCATION_LENGTH || location.isBlank()) {
             throw new InvalidLocationException();
         }
-        return new Conference(name, period, location);
+        return new Conference(name, period, organizer, location, type);
     }
 
-    public void updateName(String name){
+    public void updateName(String name) {
         this.name = name;
     }
-    public void updateLocation(String location){
+
+    public void updateLocation(String location) {
         this.location = location;
     }
-    public void updatePeriod(TimePeriod period){
+
+    public void updatePeriod(TimePeriod period) {
         this.period = period;
     }
 }

--- a/src/main/java/com/synergy/backend/domain/conference/entity/InvalidCommonException.java
+++ b/src/main/java/com/synergy/backend/domain/conference/entity/InvalidCommonException.java
@@ -1,0 +1,11 @@
+package com.synergy.backend.domain.conference.entity;
+
+import com.synergy.backend.global.exception.BaseErrorException;
+
+import static com.synergy.backend.domain.conference.exception.ErrorType._INVALID_COMMON;
+
+public class InvalidCommonException extends BaseErrorException {
+    public InvalidCommonException() {
+        super(_INVALID_COMMON.getCode(), _INVALID_COMMON.getMessage());
+    }
+}

--- a/src/main/java/com/synergy/backend/domain/conference/entity/InvalidOrganizerException.java
+++ b/src/main/java/com/synergy/backend/domain/conference/entity/InvalidOrganizerException.java
@@ -1,0 +1,11 @@
+package com.synergy.backend.domain.conference.entity;
+
+import com.synergy.backend.global.exception.BaseErrorException;
+
+import static com.synergy.backend.domain.conference.exception.ErrorType._INVALID_ORGANIZER;
+
+public class InvalidOrganizerException extends BaseErrorException {
+    public InvalidOrganizerException() {
+        super(_INVALID_ORGANIZER.getCode(), _INVALID_ORGANIZER.getMessage());
+    }
+}

--- a/src/main/java/com/synergy/backend/domain/conference/exception/ErrorType.java
+++ b/src/main/java/com/synergy/backend/domain/conference/exception/ErrorType.java
@@ -9,7 +9,8 @@ import lombok.Getter;
 public enum ErrorType {
 
     _INVALID_TIME_PERIOD(400, "시작 날짜는 더 빨라야 합니다."),
-    _INVALID_CONFERENCE_NAME(400, "컨퍼런스명은 공백이나 50자를 넘어갈 수 없습니다."),
+    _INVALID_CONFERENCE_NAME(400, "컨퍼런스명은 공백이나 30자를 넘어갈 수 없습니다."),
+    _INVALID_COMMON(400, " 주최자명, 컨퍼런스 유형은 50자를 넘어갈 수 없습니다."),
     _INVALID_CONFERENCE_LOCATION(400, "위치 정보는 공백이나 100자를 넘어갈 수 없습니다."),
     _NOT_FOUND_CONFERENCE(404, "해당 컨퍼런스를 찾을 수 없습니다.")
     ;

--- a/src/main/java/com/synergy/backend/domain/conference/exception/ErrorType.java
+++ b/src/main/java/com/synergy/backend/domain/conference/exception/ErrorType.java
@@ -10,7 +10,8 @@ public enum ErrorType {
 
     _INVALID_TIME_PERIOD(400, "시작 날짜는 더 빨라야 합니다."),
     _INVALID_CONFERENCE_NAME(400, "컨퍼런스명은 공백이나 30자를 넘어갈 수 없습니다."),
-    _INVALID_COMMON(400, " 주최자명, 컨퍼런스 유형은 50자를 넘어갈 수 없습니다."),
+    _INVALID_COMMON(400, "컨퍼런스 유형은 50자를 넘어갈 수 없습니다."),
+    _INVALID_ORGANIZER(400, "주최자 명은 10자를 넘어갈 수 없습니다."),
     _INVALID_CONFERENCE_LOCATION(400, "위치 정보는 공백이나 100자를 넘어갈 수 없습니다."),
     _NOT_FOUND_CONFERENCE(404, "해당 컨퍼런스를 찾을 수 없습니다.")
     ;

--- a/src/main/java/com/synergy/backend/domain/conference/service/ConferenceServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/conference/service/ConferenceServiceImpl.java
@@ -26,7 +26,7 @@ public class ConferenceServiceImpl implements ConferenceService {
     @Override
     public ConferenceCreateResponse registerConference(ConferenceCreateRequest request) {
         TimePeriod timePeriod = TimePeriod.of(request.startDate(), request.endDate());
-        Conference conference = Conference.of(request.name(), timePeriod, request.location());
+        Conference conference = Conference.of(request.name(), timePeriod, request.organizer(), request.location(), request.type());
         Conference savedConference = conferenceRepository.save(conference);
 
         return ConferenceCreateResponse.from(savedConference);

--- a/src/main/java/com/synergy/backend/domain/conference/service/ConferenceServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/conference/service/ConferenceServiceImpl.java
@@ -50,6 +50,8 @@ public class ConferenceServiceImpl implements ConferenceService {
     private void applyUpdatesToConference(ConferenceUpdateRequest request, Conference findConference) {
         Optional.ofNullable(request.name()).ifPresent(findConference::updateName);
         Optional.ofNullable(request.location()).ifPresent(findConference::updateLocation);
+        Optional.ofNullable(request.organizer()).ifPresent(findConference::updateOrganizer);
+        Optional.ofNullable(request.type()).ifPresent(findConference::updateType);
 
         Optional<LocalDateTime> optionalStartTime = Optional.ofNullable(request.startTime());
         Optional<LocalDateTime> optionalEndTime = Optional.ofNullable(request.endTime());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,13 +3,17 @@ spring:
     url: jdbc:mysql://localhost:3306/conference
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: root
-    password: root1234!@
+    password: rla363636!
 
   jpa:
     hibernate:
-      ddl-auto: create
-      show-sql: true
-      open-in-view: false
+      ddl-auto: update
+
     properties:
       hibernate:
         format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        ddl-auto: create-drop
+        show-sql: true
+        open-in-view: false
+

--- a/src/test/java/com/synergy/backend/domain/conference/entity/ConferenceTest.java
+++ b/src/test/java/com/synergy/backend/domain/conference/entity/ConferenceTest.java
@@ -11,8 +11,7 @@ import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 
-import static com.synergy.backend.domain.conference.exception.ErrorType._INVALID_CONFERENCE_LOCATION;
-import static com.synergy.backend.domain.conference.exception.ErrorType._INVALID_CONFERENCE_NAME;
+import static com.synergy.backend.domain.conference.exception.ErrorType.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -77,22 +76,22 @@ class ConferenceTest {
         String type = "산업";
         // when & then
         return List.of(
-                DynamicTest.dynamicTest("주최자명은 공백으로 작성할 수 없습니다..", () -> {
+                DynamicTest.dynamicTest("주최자명은 공백으로 작성할 수 없습니다.", () -> {
                             //given
                             String organizer = " ";
                             // when & then
                             assertThatThrownBy(() -> Conference.of(name, timePeriod, organizer, location, type))
-                                    .hasMessage(_INVALID_CONFERENCE_NAME.getMessage())
-                                    .isInstanceOf(InvalidNameException.class);
+                                    .hasMessage(_INVALID_COMMON.getMessage())
+                                    .isInstanceOf(InvalidCommonException.class);
                         }
                 ),
-                DynamicTest.dynamicTest("컨퍼런스 제목은 30자 이내 입니다.", () -> {
+                DynamicTest.dynamicTest("주최자명은 50자자 이내 입니다.", () -> {
                             //given
-                            String organizer = "김 승진 수수깡, 김 승진 수수깡, 김 승진 수수깡, 김 승진 수수깡, 김 승진 수수깡, ";
+                            String organizer = "김 승진 수수깡, 김 승진 수수깡, 김 승진 수수깡, 김 승진 수수깡, 김 승진 수수깡, /";
                             // when & then
                             assertThatThrownBy(() -> Conference.of(name, timePeriod, organizer, location, type))
-                                    .hasMessage(_INVALID_CONFERENCE_NAME.getMessage())
-                                    .isInstanceOf(InvalidNameException.class);
+                                    .hasMessage(_INVALID_COMMON.getMessage())
+                                    .isInstanceOf(InvalidCommonException.class);
                         }
                 )
         );
@@ -119,7 +118,7 @@ class ConferenceTest {
                 ),
                 DynamicTest.dynamicTest("컨퍼런스 위치는 100자 이내 입니다.", () -> {
                             //given
-                            String location = "지구에 존재하는 동양 국가로 대한민국 서울특별시에 존재하는 어쩌구 저쩌구 어쩌구 저쩌구 어쩌구 저쩌구 어쩌구 저쩌구저쩌구저쩌구저쩌구저쩌구저쩌구저쩌구저쩌구  마포에 있는 커스텀 건물";
+                            String location = "지구에 존재하는 동양 국가로 대한민국 서울특별시에 존재하는 어쩌구 저쩌구 어쩌구 저쩌구 어쩌구 저쩌구 어쩌구 저쩌구저쩌구저쩌구저쩌구저쩌구저쩌구저쩌구저쩌구 마포에 있는 커스텀 건물12";
 
                             // when & then
                             assertThatThrownBy(() -> Conference.of(name, timePeriod, organizer, location, type))
@@ -132,7 +131,7 @@ class ConferenceTest {
 
     @DisplayName("잘못된 유형 형식으로 등록하는 시나리오")
     @TestFactory
-    Collection<DynamicTest> ofExceptionTpye() {
+    Collection<DynamicTest> ofExceptionType() {
         // given
         TimePeriod timePeriod = TimePeriod.of(LocalDateTime.of(2025, 4, 14, 9, 0), LocalDateTime.of(2025, 4, 15, 16, 0));
         String name = "카카오 IT 컨퍼런스";
@@ -145,8 +144,8 @@ class ConferenceTest {
                             String type = "  ";
                             // when & then
                             assertThatThrownBy(() -> Conference.of(name, timePeriod, organizer, location, type))
-                                    .hasMessage(_INVALID_CONFERENCE_NAME.getMessage())
-                                    .isInstanceOf(InvalidNameException.class);
+                                    .hasMessage(_INVALID_COMMON.getMessage())
+                                    .isInstanceOf(InvalidCommonException.class);
                         }
                 ),
                 DynamicTest.dynamicTest("유형은 50자 이내 입니다.", () -> {
@@ -154,8 +153,8 @@ class ConferenceTest {
                             String type = "  ";
                             // when & then
                             assertThatThrownBy(() -> Conference.of(name, timePeriod, organizer, location, type))
-                                    .hasMessage(_INVALID_CONFERENCE_NAME.getMessage())
-                                    .isInstanceOf(InvalidNameException.class);
+                                    .hasMessage(_INVALID_COMMON.getMessage())
+                                    .isInstanceOf(InvalidCommonException.class);
                         }
                 )
         );

--- a/src/test/java/com/synergy/backend/domain/conference/entity/ConferenceTest.java
+++ b/src/test/java/com/synergy/backend/domain/conference/entity/ConferenceTest.java
@@ -78,20 +78,20 @@ class ConferenceTest {
         return List.of(
                 DynamicTest.dynamicTest("주최자명은 공백으로 작성할 수 없습니다.", () -> {
                             //given
-                            String organizer = " ";
+                            String organizer = "  ";
                             // when & then
                             assertThatThrownBy(() -> Conference.of(name, timePeriod, organizer, location, type))
-                                    .hasMessage(_INVALID_COMMON.getMessage())
-                                    .isInstanceOf(InvalidCommonException.class);
+                                    .hasMessage(_INVALID_ORGANIZER.getMessage())
+                                    .isInstanceOf(InvalidOrganizerException.class);
                         }
                 ),
-                DynamicTest.dynamicTest("주최자명은 50자자 이내 입니다.", () -> {
+                DynamicTest.dynamicTest("주최자명은 10자 이내 입니다.", () -> {
                             //given
-                            String organizer = "김 승진 수수깡, 김 승진 수수깡, 김 승진 수수깡, 김 승진 수수깡, 김 승진 수수깡, /";
+                            String organizer = "김 승진 수수깡, /";
                             // when & then
                             assertThatThrownBy(() -> Conference.of(name, timePeriod, organizer, location, type))
-                                    .hasMessage(_INVALID_COMMON.getMessage())
-                                    .isInstanceOf(InvalidCommonException.class);
+                                    .hasMessage(_INVALID_ORGANIZER.getMessage())
+                                    .isInstanceOf(InvalidOrganizerException.class);
                         }
                 )
         );

--- a/src/test/java/com/synergy/backend/domain/conference/entity/ConferenceTest.java
+++ b/src/test/java/com/synergy/backend/domain/conference/entity/ConferenceTest.java
@@ -24,13 +24,15 @@ class ConferenceTest {
         // given
         String name = "컨퍼런스 제목";
         TimePeriod timePeriod = TimePeriod.of(LocalDateTime.of(2025, 4, 14, 9, 0), LocalDateTime.of(2025, 4, 15, 16, 0));
+        String organizer = "김승진";
         String location = "컨퍼런스 위치";
+        String type = "IT";
         // when
-        Conference conference = Conference.of(name, timePeriod, location);
+        Conference conference = Conference.of(name, timePeriod, organizer, location, type);
         // then
         assertThat(conference)
-                .extracting("name", "location")
-                .containsExactly(name, location);
+                .extracting("name", "organizer", "location", "type")
+                .containsExactly(name, organizer, location, type);
     }
 
     @DisplayName("잘못된 컨퍼런스명 형식으로 등록하는 시나리오")

--- a/src/test/java/com/synergy/backend/domain/conference/entity/ConferenceTest.java
+++ b/src/test/java/com/synergy/backend/domain/conference/entity/ConferenceTest.java
@@ -40,25 +40,57 @@ class ConferenceTest {
     Collection<DynamicTest> ofExceptionName() {
         // given
         TimePeriod timePeriod = TimePeriod.of(LocalDateTime.of(2025, 4, 14, 9, 0), LocalDateTime.of(2025, 4, 15, 16, 0));
+        String location = "컨퍼런스 위치";
+        String organizer = "김승진";
+        String type = "산업";
 
         // when & then
         return List.of(
                 DynamicTest.dynamicTest("컨퍼런스 제목은 공백으로 작성할 수 없습니다..", () -> {
                             //given
                             String name = "  ";
-                            String location = "컨퍼런스 위치";
                             // when & then
-                            assertThatThrownBy(() -> Conference.of(name, timePeriod, location))
+                            assertThatThrownBy(() -> Conference.of(name, timePeriod, organizer, location, type))
                                     .hasMessage(_INVALID_CONFERENCE_NAME.getMessage())
                                     .isInstanceOf(InvalidNameException.class);
                         }
                 ),
-                DynamicTest.dynamicTest("컨퍼런스 제목은 50자 이내 입니다.", () -> {
+                DynamicTest.dynamicTest("컨퍼런스 제목은 30자 이내 입니다.", () -> {
                             //given
-                            String name = "123456789/123456789/123456789/123456789/123456789/1";
-                            String location = "컨퍼런스 위치";
+                            String name = "123456789/123456789/123456789/1";
                             // when & then
-                            assertThatThrownBy(() -> Conference.of(name, timePeriod, location))
+                            assertThatThrownBy(() -> Conference.of(name, timePeriod, organizer, location, type))
+                                    .hasMessage(_INVALID_CONFERENCE_NAME.getMessage())
+                                    .isInstanceOf(InvalidNameException.class);
+                        }
+                )
+        );
+    }
+
+    @DisplayName("잘못된 주최자명 형식으로 등록하는 시나리오")
+    @TestFactory
+    Collection<DynamicTest> ofExceptionOrganizer() {
+        // given
+        TimePeriod timePeriod = TimePeriod.of(LocalDateTime.of(2025, 4, 14, 9, 0), LocalDateTime.of(2025, 4, 15, 16, 0));
+        String name = "카카오 IT 컨퍼런스";
+        String location = "컨퍼런스 위치";
+        String type = "산업";
+        // when & then
+        return List.of(
+                DynamicTest.dynamicTest("주최자명은 공백으로 작성할 수 없습니다..", () -> {
+                            //given
+                            String organizer = " ";
+                            // when & then
+                            assertThatThrownBy(() -> Conference.of(name, timePeriod, organizer, location, type))
+                                    .hasMessage(_INVALID_CONFERENCE_NAME.getMessage())
+                                    .isInstanceOf(InvalidNameException.class);
+                        }
+                ),
+                DynamicTest.dynamicTest("컨퍼런스 제목은 30자 이내 입니다.", () -> {
+                            //given
+                            String organizer = "김 승진 수수깡, 김 승진 수수깡, 김 승진 수수깡, 김 승진 수수깡, 김 승진 수수깡, ";
+                            // when & then
+                            assertThatThrownBy(() -> Conference.of(name, timePeriod, organizer, location, type))
                                     .hasMessage(_INVALID_CONFERENCE_NAME.getMessage())
                                     .isInstanceOf(InvalidNameException.class);
                         }
@@ -71,27 +103,26 @@ class ConferenceTest {
     Collection<DynamicTest> ofExceptionLocation() {
         // given
         TimePeriod timePeriod = TimePeriod.of(LocalDateTime.of(2025, 4, 14, 9, 0), LocalDateTime.of(2025, 4, 15, 16, 0));
-
+        String name = "카카오 IT 컨퍼런스";
+        String organizer = "김승진";
+        String type = "산업";
         // when & then
         return List.of(
                 DynamicTest.dynamicTest("컨퍼런스 위치는 공백으로 작성할 수 없습니다..", () -> {
                             //given
-                            String name = "컨퍼런스명";
                             String location = "  ";
                             // when & then
-                            assertThatThrownBy(() -> Conference.of(name, timePeriod, location))
+                            assertThatThrownBy(() -> Conference.of(name, timePeriod, organizer, location, type))
                                     .hasMessage(_INVALID_CONFERENCE_LOCATION.getMessage())
                                     .isInstanceOf(InvalidLocationException.class);
                         }
                 ),
                 DynamicTest.dynamicTest("컨퍼런스 위치는 100자 이내 입니다.", () -> {
                             //given
-                            String name = "컨퍼런스명";
-                            String location = "123456789/123456789/123456789/123456789/123456789" +
-                                    "/123456789/123456789/123456789/123456789/123456789/1";
+                            String location = "지구에 존재하는 동양 국가로 대한민국 서울특별시에 존재하는 어쩌구 저쩌구 어쩌구 저쩌구 어쩌구 저쩌구 어쩌구 저쩌구저쩌구저쩌구저쩌구저쩌구저쩌구저쩌구저쩌구  마포에 있는 커스텀 건물";
 
                             // when & then
-                            assertThatThrownBy(() -> Conference.of(name, timePeriod, location))
+                            assertThatThrownBy(() -> Conference.of(name, timePeriod, organizer, location, type))
                                     .hasMessage(_INVALID_CONFERENCE_LOCATION.getMessage())
                                     .isInstanceOf(InvalidLocationException.class);
                         }
@@ -99,4 +130,34 @@ class ConferenceTest {
         );
     }
 
+    @DisplayName("잘못된 유형 형식으로 등록하는 시나리오")
+    @TestFactory
+    Collection<DynamicTest> ofExceptionTpye() {
+        // given
+        TimePeriod timePeriod = TimePeriod.of(LocalDateTime.of(2025, 4, 14, 9, 0), LocalDateTime.of(2025, 4, 15, 16, 0));
+        String name = "카카오 IT 컨퍼런스";
+        String organizer = "김승진";
+        String location = "서울 마포대로 지하 축제 공간";
+        // when & then
+        return List.of(
+                DynamicTest.dynamicTest("유형은 공백으로 작성할 수 없습니다..", () -> {
+                            //given
+                            String type = "  ";
+                            // when & then
+                            assertThatThrownBy(() -> Conference.of(name, timePeriod, organizer, location, type))
+                                    .hasMessage(_INVALID_CONFERENCE_NAME.getMessage())
+                                    .isInstanceOf(InvalidNameException.class);
+                        }
+                ),
+                DynamicTest.dynamicTest("유형은 50자 이내 입니다.", () -> {
+                            //given
+                            String type = "  ";
+                            // when & then
+                            assertThatThrownBy(() -> Conference.of(name, timePeriod, organizer, location, type))
+                                    .hasMessage(_INVALID_CONFERENCE_NAME.getMessage())
+                                    .isInstanceOf(InvalidNameException.class);
+                        }
+                )
+        );
+    }
 }

--- a/src/test/java/com/synergy/backend/domain/conference/service/ConferenceServiceImplTest.java
+++ b/src/test/java/com/synergy/backend/domain/conference/service/ConferenceServiceImplTest.java
@@ -38,7 +38,9 @@ class ConferenceServiceImplTest {
                 "컨퍼런스명",
                 LocalDateTime.of(2025,5,10,9,0),
                 LocalDateTime.of(2025,5,11,18,0),
-                "부천시 오정구 고강동 311-25 1층"
+                "부천시 오정구 고강동 311-25 1층",
+                "김승진",
+                "IT"
         );
         // when
         ConferenceCreateResponse result = conferenceService.registerConference(request);

--- a/src/test/java/com/synergy/backend/domain/conference/service/ConferenceServiceImplTest.java
+++ b/src/test/java/com/synergy/backend/domain/conference/service/ConferenceServiceImplTest.java
@@ -59,9 +59,11 @@ class ConferenceServiceImplTest {
         LocalDateTime startTime = LocalDateTime.of(2024, 3, 5, 13, 0);
         LocalDateTime endTime = LocalDateTime.of(2024, 3, 5, 20, 0);
         String location = "뉴욕 뉴져지";
+        String organizer = "김승진";
+        String type = "IT";
 
         Conference savedConference = conferenceRepository.save(
-                Conference.of(name, TimePeriod.of(startTime, endTime), location)
+                Conference.of(name, TimePeriod.of(startTime, endTime), organizer, location, type)
         );
         Long conferenceId = savedConference.getId();
 

--- a/src/test/java/com/synergy/backend/domain/conference/service/ConferenceServiceImplTest.java
+++ b/src/test/java/com/synergy/backend/domain/conference/service/ConferenceServiceImplTest.java
@@ -71,13 +71,15 @@ class ConferenceServiceImplTest {
         LocalDateTime updatedStartTime = LocalDateTime.of(2024, 3, 5, 15, 0);
         LocalDateTime updatedEndTime = LocalDateTime.of(2024, 3, 5, 19, 0);
         String updatedLocation = "서울 여의도 국회 1층";
+        String updatedOrganizer = "뽀로로";
+        String updatedType = "산업";
         // when & then
         return List.of(
                 DynamicTest.dynamicTest("컨퍼런스명을 수정합니다.", () -> {
                         //given
 
                         ConferenceUpdateRequest request = new ConferenceUpdateRequest(
-                                updatedName, null, null, null
+                                updatedName, null, null, null, null, null
                         );
                         //when
                         ConferenceUpdateResponse result = conferenceService.updateConference(conferenceId, request);
@@ -86,18 +88,22 @@ class ConferenceServiceImplTest {
                                     .extracting(ConferenceUpdateResponse::name,
                                             ConferenceUpdateResponse::startTime,
                                             ConferenceUpdateResponse::endTime,
-                                            ConferenceUpdateResponse::location)
+                                            ConferenceUpdateResponse::location,
+                                            ConferenceUpdateResponse::organizer,
+                                            ConferenceUpdateResponse::type)
                                     .containsExactly(updatedName,
                                             savedConference.getPeriod().getStartDateTime(),
                                             savedConference.getPeriod().getEndDateTime(),
-                                            savedConference.getLocation()
+                                            savedConference.getLocation(),
+                                            savedConference.getOrganizer(),
+                                            savedConference.getType()
                                     );
                     }
                 ),
                 DynamicTest.dynamicTest("위치 정보를 수정합니다.", () -> {
                             //given
                             ConferenceUpdateRequest request = new ConferenceUpdateRequest(
-                                    null, null, null, updatedLocation
+                                    null, null, null, updatedLocation, null, null
                             );
                             //when
                             ConferenceUpdateResponse result = conferenceService.updateConference(conferenceId, request);
@@ -106,19 +112,23 @@ class ConferenceServiceImplTest {
                                     .extracting(ConferenceUpdateResponse::name,
                                             ConferenceUpdateResponse::startTime,
                                             ConferenceUpdateResponse::endTime,
-                                            ConferenceUpdateResponse::location)
+                                            ConferenceUpdateResponse::location,
+                                            ConferenceUpdateResponse::organizer,
+                                            ConferenceUpdateResponse::type)
                                     .containsExactly(
                                             updatedName,
                                             savedConference.getPeriod().getStartDateTime(),
                                             savedConference.getPeriod().getEndDateTime(),
-                                            updatedLocation
+                                            updatedLocation,
+                                            savedConference.getOrganizer(),
+                                            savedConference.getType()
                                     );
                         }
                 ),
                 DynamicTest.dynamicTest("컨퍼런스 기간을 수정합니다.", () -> {
                             //given
                             ConferenceUpdateRequest request = new ConferenceUpdateRequest(
-                                    null, updatedStartTime, updatedEndTime, null
+                                    null, updatedStartTime, updatedEndTime, null, null, null
                             );
                             //when
                             ConferenceUpdateResponse result = conferenceService.updateConference(conferenceId, request);
@@ -127,12 +137,69 @@ class ConferenceServiceImplTest {
                                     .extracting(ConferenceUpdateResponse::name,
                                             ConferenceUpdateResponse::startTime,
                                             ConferenceUpdateResponse::endTime,
-                                            ConferenceUpdateResponse::location)
+                                            ConferenceUpdateResponse::location,
+                                            ConferenceUpdateResponse::organizer,
+                                            ConferenceUpdateResponse::type
+                                    )
                                     .containsExactly(
                                             updatedName,
                                             updatedStartTime,
                                             updatedEndTime,
-                                            updatedLocation
+                                            updatedLocation,
+                                            savedConference.getOrganizer(),
+                                            savedConference.getType()
+                                    );
+                        }
+                ),
+                DynamicTest.dynamicTest("주최자를 수정합니다.", () -> {
+                            //given
+                            ConferenceUpdateRequest request = new ConferenceUpdateRequest(
+                                    null, null, null, null, updatedOrganizer, null
+                            );
+                            //when
+                            ConferenceUpdateResponse result = conferenceService.updateConference(conferenceId, request);
+                            //then
+                            assertThat(result)
+                                    .extracting(ConferenceUpdateResponse::name,
+                                            ConferenceUpdateResponse::startTime,
+                                            ConferenceUpdateResponse::endTime,
+                                            ConferenceUpdateResponse::location,
+                                            ConferenceUpdateResponse::organizer,
+                                            ConferenceUpdateResponse::type
+                                    )
+                                    .containsExactly(
+                                            updatedName,
+                                            updatedStartTime,
+                                            updatedEndTime,
+                                            updatedLocation,
+                                            savedConference.getOrganizer(),
+                                            savedConference.getType()
+                                    );
+                        }
+                ),
+                DynamicTest.dynamicTest("유형을 수정합니다.", () -> {
+                            //given
+                            ConferenceUpdateRequest request = new ConferenceUpdateRequest(
+                                    null, null, null, null, null, type
+                            );
+                            //when
+                            ConferenceUpdateResponse result = conferenceService.updateConference(conferenceId, request);
+                            //then
+                            assertThat(result)
+                                    .extracting(ConferenceUpdateResponse::name,
+                                            ConferenceUpdateResponse::startTime,
+                                            ConferenceUpdateResponse::endTime,
+                                            ConferenceUpdateResponse::location,
+                                            ConferenceUpdateResponse::organizer,
+                                            ConferenceUpdateResponse::type
+                                    )
+                                    .containsExactly(
+                                            updatedName,
+                                            updatedStartTime,
+                                            updatedEndTime,
+                                            updatedLocation,
+                                            savedConference.getOrganizer(),
+                                            savedConference.getType()
                                     );
                         }
                 )


### PR DESCRIPTION
📌 진행한 이슈
close #20 Conference 요구사항에 맞게 수정(https://github.com/Goorm-Synergy/Synergy-Backend/issues/20)

📌 구현 내용
<img width="418" alt="image" src="https://github.com/user-attachments/assets/9ad170d6-79fa-451e-ae7f-0b6679e9282a" />

컨퍼런스에 주최자와 컨퍼런스 유형이라는 요소가 추가되어 이에 맞게 기능 변경 이후, 테스트 검수 마쳤습니다.
개발 기한이 남는다면 구현하지 않은 단위 테스트, 통합 테스트 유형 혹은 검증하지 않은 예외 요소에 대해 테스트 구현하여 서비스 신뢰도를 높일 예정입니다.

📌 참고 자료
<img width="401" alt="image" src="https://github.com/user-attachments/assets/21a351c4-7857-4635-a3e6-fb47f1dc4e35" />
시간 관계 상, PM님 요구사항과 일부 다르게 구현한 부분이 있습니다. 위치 선택과 컨퍼런스 선택을 보면 하나의 값을 프론트에서 넘기기에 enum에 대한 처리를 하지 않았습니다. 실제 다른값이 온다면 문제가 될 수 있겠지만 추후 프론트 서버에서만 요청을 받기에 당장 큰 문제가 되지 않기에 String 값으로 처리했습니다. 기능의 확장이 있다면  추후 enum 으로 승격할 예정입니다.

<img width="388" alt="image" src="https://github.com/user-attachments/assets/afa29d93-ec74-4283-b615-6bd730f0dc3d" />

이에 맞게 테이블도 변경되었고 테이블 기준으로 도메인 반영했습니다.

참고로 yml 파일 문법이 잘못되었기에 임시로 수정했습니다. 개인 PC에서는 방언 문제가 발생하여 방언 옵션도 추가했습니다. 테스트를 위해 저의 개인 pc db로 올려 진행했고 추후 환경 변수로 yml 파일 통합하여 사용하면 좋아 보입니다.
