### PR TITLE
feat: 포인트 도메인 생성

### DIFF
--- a/src/main/java/com/synergy/backend/domain/member/entity/Attendee.java
+++ b/src/main/java/com/synergy/backend/domain/member/entity/Attendee.java
@@ -39,7 +39,7 @@ public class Attendee extends Member {
 	// 현재 포인트 합계
 	@Column(nullable = false)
 	@Builder.Default
-	private int point = 0;
+	private int totalPoints = 0;
 
 	// 등급
 	@Column(nullable = false)

--- a/src/main/java/com/synergy/backend/domain/member/entity/Attendee.java
+++ b/src/main/java/com/synergy/backend/domain/member/entity/Attendee.java
@@ -2,10 +2,12 @@ package com.synergy.backend.domain.member.entity;
 
 import static jakarta.persistence.FetchType.*;
 
+import java.util.List;
 import java.util.Set;
 
 import com.synergy.backend.domain.conference.entity.Conference;
 import com.synergy.backend.domain.interest.entity.MemberInterest;
+import com.synergy.backend.domain.point.entity.Point;
 import com.synergy.backend.domain.techstack.entity.MemberTechStack;
 
 import jakarta.persistence.CascadeType;
@@ -46,6 +48,9 @@ public class Attendee extends Member {
 	@Enumerated(EnumType.STRING)
 	@Builder.Default
 	private MembershipLevelType membershipLevelType = MembershipLevelType.BRONZE;
+
+	@OneToMany(mappedBy = "attendee", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Point> points;
 
 	// 현재 직업
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/com/synergy/backend/domain/member/entity/MembershipLevelType.java
+++ b/src/main/java/com/synergy/backend/domain/member/entity/MembershipLevelType.java
@@ -5,6 +5,13 @@ public enum MembershipLevelType {
 	GOLD,
 	SILVER,
 	BRONZE,
-	DIAMOND
+	DEFAULT;
 
+	public static MembershipLevelType getMembershipLevel(int point) {
+		if (point >= 1500) return PLATINUM;
+		if (point >= 800) return GOLD;
+		if (point >= 300) return SILVER;
+		if (point >= 100) return BRONZE;
+		return DEFAULT;
+	}
 }

--- a/src/main/java/com/synergy/backend/domain/point/entity/Point.java
+++ b/src/main/java/com/synergy/backend/domain/point/entity/Point.java
@@ -1,8 +1,8 @@
 package com.synergy.backend.domain.point.entity;
 
-import com.synergy.backend.domain.member.entity.MembershipLevelType;
 import com.synergy.backend.global.common.BaseEntity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -23,11 +23,7 @@ public class Point extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	private String content;
-
-	@Enumerated(EnumType.STRING)
-	private MembershipLevelType membershipLevelType;
-
+	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
 	private PointType pointType;
 
@@ -35,36 +31,13 @@ public class Point extends BaseEntity {
 	private Long sessionId; // 세션 참여 시 세션 ID 저장
 	private Long sessionQnAId; // 세션 Q&A 참여 시 세션 Q&A ID 저장
 	private Long recruiterId; // 채용 담당자 미팅 시 담당자 ID 저장
-	// private Long surveyId; // 설문조사 참여 시 설문 ID 저장
-	// private String sharedContentUrl; // 컨텐츠 공유 시 공유한 URL 저장
 
 	@Builder
-	public Point(PointType pointType, Long boothId, Long sessionId, Long recruiterId) {
+	public Point(PointType pointType, Long boothId, Long sessionId, Long sessionQnAId, Long recruiterId) {
 		this.pointType = pointType;
 		this.boothId = boothId;
 		this.sessionId = sessionId;
+		this.sessionQnAId = sessionQnAId;
 		this.recruiterId = recruiterId;
-		this.content = generateContent(pointType, boothId, sessionId, recruiterId);
-		this.membershipLevelType = MembershipLevelType.BRONZE; // 기본값
-	}
-
-	// 포인트 지급 사유 생성
-	private String generateContent(PointType pointType, Long boothId, Long sessionId, Long recruiterId) {
-		switch (pointType) {
-			case SIGN_UP:
-				return "회원가입 포인트 적립";
-			case BOOTH_VISIT:
-				return "부스 방문 포인트 적립 (부스 ID: " + boothId + ")";
-			case SESSION_ATTEND:
-				return "세션 참여 포인트 적립 (세션 ID: " + sessionId + ")";
-			case SURVEY_PARTICIPATION:
-				return "설문조사 참여 포인트 적립";
-			case CONTENT_SHARE:
-				return "컨텐츠 공유 포인트 적립";
-			case RECRUITER_MEETING:
-				return "채용 담당자 미팅 포인트 적립 (담당자 ID: " + recruiterId + ")";
-			default:
-				return "포인트 적립";
-		}
 	}
 }

--- a/src/main/java/com/synergy/backend/domain/point/entity/Point.java
+++ b/src/main/java/com/synergy/backend/domain/point/entity/Point.java
@@ -1,0 +1,70 @@
+package com.synergy.backend.domain.point.entity;
+
+import com.synergy.backend.domain.member.entity.MembershipLevelType;
+import com.synergy.backend.global.common.BaseEntity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Point extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String content;
+
+	@Enumerated(EnumType.STRING)
+	private MembershipLevelType membershipLevelType;
+
+	@Enumerated(EnumType.STRING)
+	private PointType pointType;
+
+	private Long boothId;  // 부스 방문 시 부스 ID 저장
+	private Long sessionId; // 세션 참여 시 세션 ID 저장
+	private Long sessionQnAId; // 세션 Q&A 참여 시 세션 Q&A ID 저장
+	private Long recruiterId; // 채용 담당자 미팅 시 담당자 ID 저장
+	// private Long surveyId; // 설문조사 참여 시 설문 ID 저장
+	// private String sharedContentUrl; // 컨텐츠 공유 시 공유한 URL 저장
+
+	@Builder
+	public Point(PointType pointType, Long boothId, Long sessionId, Long recruiterId) {
+		this.pointType = pointType;
+		this.boothId = boothId;
+		this.sessionId = sessionId;
+		this.recruiterId = recruiterId;
+		this.content = generateContent(pointType, boothId, sessionId, recruiterId);
+		this.membershipLevelType = MembershipLevelType.BRONZE; // 기본값
+	}
+
+	// 포인트 지급 사유 생성
+	private String generateContent(PointType pointType, Long boothId, Long sessionId, Long recruiterId) {
+		switch (pointType) {
+			case SIGN_UP:
+				return "회원가입 포인트 적립";
+			case BOOTH_VISIT:
+				return "부스 방문 포인트 적립 (부스 ID: " + boothId + ")";
+			case SESSION_ATTEND:
+				return "세션 참여 포인트 적립 (세션 ID: " + sessionId + ")";
+			case SURVEY_PARTICIPATION:
+				return "설문조사 참여 포인트 적립";
+			case CONTENT_SHARE:
+				return "컨텐츠 공유 포인트 적립";
+			case RECRUITER_MEETING:
+				return "채용 담당자 미팅 포인트 적립 (담당자 ID: " + recruiterId + ")";
+			default:
+				return "포인트 적립";
+		}
+	}
+}

--- a/src/main/java/com/synergy/backend/domain/point/entity/PointType.java
+++ b/src/main/java/com/synergy/backend/domain/point/entity/PointType.java
@@ -1,21 +1,19 @@
 package com.synergy.backend.domain.point.entity;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public enum PointType {
-	SIGN_UP(50),
-	BOOTH_VISIT(20),
-	SESSION_ATTEND(30),
-	SESSION_QNA(50),
-	SURVEY_PARTICIPATION(30),
-	CONTENT_SHARE(20),
-	RECRUITER_MEETING(50);
+	SIGN_UP(50, "회원가입"),
+	BOOTH_VISIT(20, "부스 방문"),
+	SESSION_ATTEND(30, "세션 참여"),
+	SESSION_QNA(50, "세션 Q&A 참여"),
+	SURVEY_PARTICIPATION(30, "설문 조사 참여"),
+	CONTENT_SHARE(20, "컨텐츠 공유 (SNS)"),
+	RECRUITER_MEETING(50, "채용 담당자 미팅");
 
 	private final int pointValue;
-
-	PointType(int pointValue) {
-		this.pointValue = pointValue;
-	}
-
+	private final String message;
 }

--- a/src/main/java/com/synergy/backend/domain/point/entity/PointType.java
+++ b/src/main/java/com/synergy/backend/domain/point/entity/PointType.java
@@ -1,0 +1,21 @@
+package com.synergy.backend.domain.point.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum PointType {
+	SIGN_UP(50),
+	BOOTH_VISIT(20),
+	SESSION_ATTEND(30),
+	SESSION_QNA(50),
+	SURVEY_PARTICIPATION(30),
+	CONTENT_SHARE(20),
+	RECRUITER_MEETING(50);
+
+	private final int pointValue;
+
+	PointType(int pointValue) {
+		this.pointValue = pointValue;
+	}
+
+}

--- a/src/main/java/com/synergy/backend/global/common/BaseEntity.java
+++ b/src/main/java/com/synergy/backend/global/common/BaseEntity.java
@@ -3,7 +3,9 @@ package com.synergy.backend.global.common;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import org.springframework.data.annotation.CreatedDate;
@@ -16,6 +18,7 @@ import java.time.LocalDateTime;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SuperBuilder
 public class BaseEntity {
     @Column(updatable = false)


### PR DESCRIPTION
close #23 

**Point 엔티티 생성**
- PointType Enum을 사용하여 포인트 지급 유형을 구분 (회원가입, 부스 방문, 세션 참여 등)
- 각 유형별 지급 포인트 값을 PointType에서 직접 관리하여 코드 유지보수성 향상
- 포인트 적립 내역에서 어떤 부스, 세션, 세션 Q&A에 참여했는지 확인할 수 있도록 해당 ID(boothId, sessionId, sessionQnAId) 저장

**MembershipLevelType 재정의**
요구사항에 맞게 등급 및 최소 포인트 기준 설정
- 기본: 0 ~ 99 포인트
- 브론즈: 100 ~ 299 포인트
- 실버: 300 ~ 799 포인트
- 골드: 800 ~ 1299 포인트
- 플래티넘: 1500+ 포인트
- MembershipLevelType 내에서 포인트 기준을 기반으로 자동으로 등급을 계산하는 메서드 추가

**erd 수정완료**
![스크린샷 2025-03-10 오후 6 43 30](https://github.com/user-attachments/assets/8ddfa616-969e-44fe-bd26-2c36ac91c064)



**참고사항**
비즈니스 로직은 아직 작성하지 않아서 테스트코드는 따로 작성하지 않았습니다..!
