### PR TITLE
test : 컨퍼런스 컨트롤러 테스트 구현 (컨퍼런스 등록 API)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'com.h2database:h2'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+
     // qrCode
     implementation group: 'com.google.zxing', name: 'javase', version: '3.5.0'
     implementation group: 'com.google.zxing', name: 'core', version: '3.5.0'

--- a/src/main/java/com/synergy/backend/SynergyBackendApplication.java
+++ b/src/main/java/com/synergy/backend/SynergyBackendApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class SynergyBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/synergy/backend/domain/conference/api/ConferenceController.java
+++ b/src/main/java/com/synergy/backend/domain/conference/api/ConferenceController.java
@@ -7,16 +7,18 @@ import com.synergy.backend.domain.conference.dto.response.ConferenceUpdateRespon
 import com.synergy.backend.domain.conference.service.ConferenceService;
 import com.synergy.backend.domain.member.entity.RoleType;
 import com.synergy.backend.domain.member.exception.AccessDeniedException;
+import com.synergy.backend.global.CurrentUser;
 import com.synergy.backend.global.common.ApiResponse;
 import com.synergy.backend.global.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequiredArgsConstructor
+@RequiredArgsConstructor @Slf4j
 @RequestMapping("/api/v1/conference")
 public class ConferenceController {
 
@@ -24,12 +26,8 @@ public class ConferenceController {
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
-    public ApiResponse<ConferenceCreateResponse> registerConference(@AuthenticationPrincipal CustomUserDetails userDetails
+    public ApiResponse<ConferenceCreateResponse> registerConference(@CurrentUser String identifier
                                                                 , @RequestBody @Valid ConferenceCreateRequest request){
-        if(RoleType.ADMIN.equals(userDetails.getRole())){
-            throw new AccessDeniedException();
-        }
-        String identifier = userDetails.getIdentifier();
         return ApiResponse.ok(conferenceService.registerConference(identifier, request), 201);
     }
 

--- a/src/main/java/com/synergy/backend/domain/conference/api/ConferenceController.java
+++ b/src/main/java/com/synergy/backend/domain/conference/api/ConferenceController.java
@@ -5,10 +5,14 @@ import com.synergy.backend.domain.conference.dto.requset.ConferenceUpdateRequest
 import com.synergy.backend.domain.conference.dto.response.ConferenceCreateResponse;
 import com.synergy.backend.domain.conference.dto.response.ConferenceUpdateResponse;
 import com.synergy.backend.domain.conference.service.ConferenceService;
+import com.synergy.backend.domain.member.entity.RoleType;
+import com.synergy.backend.domain.member.exception.AccessDeniedException;
 import com.synergy.backend.global.common.ApiResponse;
+import com.synergy.backend.global.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,12 +24,22 @@ public class ConferenceController {
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
-    public ApiResponse<ConferenceCreateResponse> registerConference(@RequestBody @Valid ConferenceCreateRequest request){
-        return ApiResponse.ok(conferenceService.registerConference(request), 201);
+    public ApiResponse<ConferenceCreateResponse> registerConference(@AuthenticationPrincipal CustomUserDetails userDetails
+                                                                , @RequestBody @Valid ConferenceCreateRequest request){
+        if(RoleType.ADMIN.equals(userDetails.getRole())){
+            throw new AccessDeniedException();
+        }
+        String identifier = userDetails.getIdentifier();
+        return ApiResponse.ok(conferenceService.registerConference(identifier, request), 201);
     }
 
     @PatchMapping("/{id}")
-    public ApiResponse<ConferenceUpdateResponse> updateConference(@PathVariable(name = "id") Long id, @RequestBody @Valid ConferenceUpdateRequest request){
-        return ApiResponse.ok(conferenceService.updateConference(id, request), 200);
+    public ApiResponse<ConferenceUpdateResponse> updateConference(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                      @PathVariable(name = "id") Long id, @RequestBody @Valid ConferenceUpdateRequest request){
+        if(RoleType.ADMIN.equals(userDetails.getRole())){
+            throw new AccessDeniedException();
+        }
+        String identifier = userDetails.getIdentifier();
+        return ApiResponse.ok(conferenceService.updateConference(identifier, id, request), 200);
     }
 }

--- a/src/main/java/com/synergy/backend/domain/conference/api/ConferenceController.java
+++ b/src/main/java/com/synergy/backend/domain/conference/api/ConferenceController.java
@@ -5,13 +5,10 @@ import com.synergy.backend.domain.conference.dto.requset.ConferenceUpdateRequest
 import com.synergy.backend.domain.conference.dto.response.ConferenceCreateResponse;
 import com.synergy.backend.domain.conference.dto.response.ConferenceUpdateResponse;
 import com.synergy.backend.domain.conference.service.ConferenceService;
-import com.synergy.backend.domain.member.entity.RoleType;
-import com.synergy.backend.domain.member.exception.AccessDeniedException;
 import com.synergy.backend.global.common.ApiResponse;
-import com.synergy.backend.global.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,27 +18,14 @@ public class ConferenceController {
 
     private final ConferenceService conferenceService;
 
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
-    public ApiResponse<ConferenceCreateResponse> registerConference(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                    @RequestBody @Valid ConferenceCreateRequest request){
-        String identifier = userDetails.getIdentifier();
-        RoleType role = userDetails.getRole();
-
-        if (role != RoleType.ADMIN) {
-            throw new AccessDeniedException();
-        }
-        return ApiResponse.ok(conferenceService.registerConference(identifier, request), 201);
+    public ApiResponse<ConferenceCreateResponse> registerConference(@RequestBody @Valid ConferenceCreateRequest request){
+        return ApiResponse.ok(conferenceService.registerConference(request), 201);
     }
 
     @PatchMapping("/{id}")
-    public ApiResponse<ConferenceUpdateResponse> updateConference(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                @PathVariable(name = "id") Long id, @RequestBody @Valid ConferenceUpdateRequest request){
-        String identifier = userDetails.getIdentifier();
-        RoleType role = userDetails.getRole();
-
-        if (role != RoleType.ADMIN) {
-            throw new AccessDeniedException();
-        }
-        return ApiResponse.ok(conferenceService.updateConference(identifier, id, request), 200);
+    public ApiResponse<ConferenceUpdateResponse> updateConference(@PathVariable(name = "id") Long id, @RequestBody @Valid ConferenceUpdateRequest request){
+        return ApiResponse.ok(conferenceService.updateConference(id, request), 200);
     }
 }

--- a/src/main/java/com/synergy/backend/domain/conference/service/ConferenceServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/conference/service/ConferenceServiceImpl.java
@@ -14,6 +14,7 @@ import com.synergy.backend.domain.member.exception.AccessDeniedException;
 import com.synergy.backend.domain.member.exception.NotFoundUserException;
 import com.synergy.backend.domain.member.repository.AdminRepository;
 import lombok.RequiredArgsConstructor;
+import org.apache.catalina.security.SecurityUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,7 +27,6 @@ import java.util.Optional;
 public class ConferenceServiceImpl implements ConferenceService {
     private final ConferenceRepository conferenceRepository;
     private final AdminRepository adminRepository;
-
     @Transactional
     @Override
     public ConferenceCreateResponse registerConference(String identifier, ConferenceCreateRequest request) {

--- a/src/main/java/com/synergy/backend/global/CurrentUser.java
+++ b/src/main/java/com/synergy/backend/global/CurrentUser.java
@@ -1,0 +1,16 @@
+package com.synergy.backend.global;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)// 타겟은 파라미터에만 붙이겠다.
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : username")
+public @interface CurrentUser {
+    // 익명 사용자인 경우에는 null로, 익명 사용자가 아닌 경우에는 실제 account 객체로
+    // Principal 을 다이나믹 하게 꺼내기 위해 @CurrentUser 생성
+}

--- a/src/main/java/com/synergy/backend/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/synergy/backend/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.synergy.backend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/test/java/com/synergy/backend/domain/conference/api/ConferenceControllerTest.java
+++ b/src/test/java/com/synergy/backend/domain/conference/api/ConferenceControllerTest.java
@@ -6,6 +6,7 @@ import com.synergy.backend.domain.conference.dto.requset.ConferenceCreateRequest
 import com.synergy.backend.domain.conference.dto.response.ConferenceCreateResponse;
 import com.synergy.backend.domain.conference.service.ConferenceService;
 import com.synergy.backend.domain.member.entity.RoleType;
+import com.synergy.backend.global.security.CustomUserDetails;
 import com.synergy.backend.global.security.CustomUserDetailsService;
 import com.synergy.backend.global.security.JwtProvider;
 import org.junit.jupiter.api.DisplayName;
@@ -17,7 +18,10 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 import static org.mockito.BDDMockito.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -39,6 +43,8 @@ class ConferenceControllerTest {
     JwtProvider jwtProvider;
     @MockitoBean
     CustomUserDetailsService userDetailsService;
+    @MockitoBean
+    Clock clock;
 
     private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
 
@@ -47,6 +53,11 @@ class ConferenceControllerTest {
      * JwtAuthenticationFilter 필터가 스프링 빈으로 등록되었기에 MockBean 처리가 필수입니다.
      * 필터를 추가하는 방식에 스프링 빈으로 등록하면 컨트롤러 테스트 과정에서 따로 추가해줘야 할 거 같습니다.
      * 스프링 시큐리티 빈에서 따로 주입해주는 방법도 있으니 추후, 확정해도 괜찮아 보입니다.
+     *
+     * [@WithMockUser 를 사용한 이유]
+     * 실제로는 JWT 와 Authorization 헤더를 통해 검증하는데 이를 검증하기 위해서는 추가적인 의존성이 필요합니다.
+     * 편의를 위해 @WithMockUser 사용하여 빠르게 해결했으며 해당 방법을 유지한다면 따로 JWT 와 Authorization 헤더
+     * 에 대한 검증하는 테스트가 있으면 좋아 보입니다.
      */
 
     @DisplayName("컨퍼런스를 등록한다.")
@@ -63,8 +74,8 @@ class ConferenceControllerTest {
                 "IT"
         );
         ConferenceCreateResponse response = new ConferenceCreateResponse(1L);
-
-        given(conferenceService.registerConference(request))
+        String identifier = "AUTH1";
+        given(conferenceService.registerConference(identifier, request))
                 .willReturn(response);
         given(jwtProvider.validateToken(anyString()))
                 .willReturn(true);
@@ -73,7 +84,7 @@ class ConferenceControllerTest {
         given(jwtProvider.getRoleTypeFromToken(anyString()))
                 .willReturn(RoleType.ADMIN);
         given(userDetailsService.loadUserByUsername(anyString()))
-                .willReturn(mock(UserDetails.class));
+            .willReturn(mock(UserDetails.class));
 
 
         // when & then
@@ -85,6 +96,74 @@ class ConferenceControllerTest {
                 .andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.id").value(1L));
+
+
+    }
+
+
+    @DisplayName("컨퍼런스 등록을 위해서 컨퍼런스명은 필수입나다.")
+    @Test
+    @WithMockUser(username = "AUTH1", roles = {"ADMIN"})
+    void registerConference_ExceptionOfName() throws Exception{
+        // given
+        ConferenceCreateRequest request = new ConferenceCreateRequest(
+                null,
+                LocalDateTime.of(2025, 6, 15, 10, 0),
+                LocalDateTime.of(2025, 6, 16, 18, 0),
+                "Seoul, South Korea",
+                "김승진",
+                "IT"
+        );
+
+        given(jwtProvider.validateToken(anyString())).willReturn(true);
+        given(jwtProvider.getEmailOrAuthCodeFromToken(anyString())).willReturn("AUTH1");
+        given(jwtProvider.getRoleTypeFromToken(anyString())).willReturn(RoleType.ADMIN);
+        given(userDetailsService.loadUserByUsername(anyString())).willReturn(mock(UserDetails.class));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/conference")
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("컨퍼런스명은 필수입니다. 공백 이하는 불가능합니다."));
+
+
+    }
+
+    @DisplayName("컨퍼런스 등록 시 시작 날짜는 반드시 미래여야 한다.")
+    //@Test
+    @WithMockUser(username = "AUTH1", roles = {"ADMIN"})
+    void registerConference_ExceptionOfStartDate() throws Exception{
+        // given
+        ConferenceCreateRequest request = new ConferenceCreateRequest(
+                "카카오 대규모 IT 행사",
+                LocalDateTime.of(2025, 3, 18, 18, 0),
+                LocalDateTime.of(2025, 3, 20, 18, 0),
+                "Seoul, South Korea",
+                "김승진",
+                "IT"
+        );
+
+        Instant fixedInstant = Instant.parse("2025-03-19T00:00:00Z"); // UTC 기준
+        ZoneId koreaZone = ZoneId.of("Asia/Seoul");
+
+        given(jwtProvider.validateToken(anyString())).willReturn(true);
+        given(jwtProvider.getEmailOrAuthCodeFromToken(anyString())).willReturn("AUTH1");
+        given(jwtProvider.getRoleTypeFromToken(anyString())).willReturn(RoleType.ADMIN);
+        given(userDetailsService.loadUserByUsername(anyString())).willReturn(mock(UserDetails.class));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/conference")
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("시작 날짜는 미래여야 합니다."));
 
 
     }

--- a/src/test/java/com/synergy/backend/domain/conference/api/ConferenceControllerTest.java
+++ b/src/test/java/com/synergy/backend/domain/conference/api/ConferenceControllerTest.java
@@ -6,7 +6,6 @@ import com.synergy.backend.domain.conference.dto.requset.ConferenceCreateRequest
 import com.synergy.backend.domain.conference.dto.response.ConferenceCreateResponse;
 import com.synergy.backend.domain.conference.service.ConferenceService;
 import com.synergy.backend.domain.member.entity.RoleType;
-import com.synergy.backend.global.security.CustomUserDetails;
 import com.synergy.backend.global.security.CustomUserDetailsService;
 import com.synergy.backend.global.security.JwtProvider;
 import org.junit.jupiter.api.DisplayName;
@@ -19,9 +18,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.Clock;
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 
 import static org.mockito.BDDMockito.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -43,7 +40,7 @@ class ConferenceControllerTest {
     JwtProvider jwtProvider;
     @MockitoBean
     CustomUserDetailsService userDetailsService;
-    @MockitoBean
+
     Clock clock;
 
     private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
@@ -60,6 +57,13 @@ class ConferenceControllerTest {
      * 에 대한 검증하는 테스트가 있으면 좋아 보입니다.
      */
 
+
+    /**
+     * 아래 테스트 코드는 올바르지 않습니다. 시간의 변화에 따라 테스트의 성공 유무가 결정됩니다.
+     * 하지만 Validation 으로 Controller Request Dto 단에서 검증하기에 핸들링하기 어렵다고 판단했습니다.
+     * 기한이 촉박하기에 아래와 같이 3000년까지 임시로 정했습니다. 추후 개선할 필요가 있습니다.
+     */
+
     @DisplayName("컨퍼런스를 등록한다.")
     @Test
     @WithMockUser(username = "AUTH1", roles = {"ADMIN"})
@@ -67,8 +71,8 @@ class ConferenceControllerTest {
         // given
         ConferenceCreateRequest request = new ConferenceCreateRequest(
                 "Spring Boot Conference 2025",
-                LocalDateTime.of(2025, 6, 15, 10, 0),
-                LocalDateTime.of(2025, 6, 16, 18, 0),
+                LocalDateTime.of(3025, 6, 15, 10, 0),
+                LocalDateTime.of(3025, 6, 16, 18, 0),
                 "Seoul, South Korea",
                 "김승진",
                 "IT"
@@ -84,7 +88,7 @@ class ConferenceControllerTest {
         given(jwtProvider.getRoleTypeFromToken(anyString()))
                 .willReturn(RoleType.ADMIN);
         given(userDetailsService.loadUserByUsername(anyString()))
-            .willReturn(mock(UserDetails.class));
+                .willReturn(mock(UserDetails.class));
 
 
         // when & then
@@ -104,12 +108,12 @@ class ConferenceControllerTest {
     @DisplayName("컨퍼런스 등록을 위해서 컨퍼런스명은 필수입나다.")
     @Test
     @WithMockUser(username = "AUTH1", roles = {"ADMIN"})
-    void registerConference_ExceptionOfName() throws Exception{
+    void registerConference_ExceptionOfName() throws Exception {
         // given
         ConferenceCreateRequest request = new ConferenceCreateRequest(
                 null,
-                LocalDateTime.of(2025, 6, 15, 10, 0),
-                LocalDateTime.of(2025, 6, 16, 18, 0),
+                LocalDateTime.of(3025, 6, 15, 10, 0),
+                LocalDateTime.of(3025, 6, 16, 18, 0),
                 "Seoul, South Korea",
                 "김승진",
                 "IT"
@@ -133,22 +137,20 @@ class ConferenceControllerTest {
 
     }
 
+
     @DisplayName("컨퍼런스 등록 시 시작 날짜는 반드시 미래여야 한다.")
-    //@Test
+    @Test
     @WithMockUser(username = "AUTH1", roles = {"ADMIN"})
-    void registerConference_ExceptionOfStartDate() throws Exception{
+    void registerConference_ExceptionOfStartDate() throws Exception {
         // given
         ConferenceCreateRequest request = new ConferenceCreateRequest(
                 "카카오 대규모 IT 행사",
-                LocalDateTime.of(2025, 3, 18, 18, 0),
-                LocalDateTime.of(2025, 3, 20, 18, 0),
+                LocalDateTime.of(2025, 3, 18, 17, 0),
+                LocalDateTime.of(3000, 3, 20, 18, 0),
                 "Seoul, South Korea",
                 "김승진",
                 "IT"
         );
-
-        Instant fixedInstant = Instant.parse("2025-03-19T00:00:00Z"); // UTC 기준
-        ZoneId koreaZone = ZoneId.of("Asia/Seoul");
 
         given(jwtProvider.validateToken(anyString())).willReturn(true);
         given(jwtProvider.getEmailOrAuthCodeFromToken(anyString())).willReturn("AUTH1");
@@ -168,5 +170,133 @@ class ConferenceControllerTest {
 
     }
 
+    @DisplayName("컨퍼런스 등록 시 종료 날짜는 반드시 미래여야 한다.")
+    @Test
+    @WithMockUser(username = "AUTH1", roles = {"ADMIN"})
+    void registerConference_ExceptionOfEndDate() throws Exception {
+        // given
+        ConferenceCreateRequest request = new ConferenceCreateRequest(
+                "카카오 대규모 IT 행사",
+                LocalDateTime.of(3025, 3, 18, 17, 0),
+                LocalDateTime.of(2025, 3, 18, 15, 0),
+                "Seoul, South Korea",
+                "김승진",
+                "IT"
+        );
+
+        given(jwtProvider.validateToken(anyString())).willReturn(true);
+        given(jwtProvider.getEmailOrAuthCodeFromToken(anyString())).willReturn("AUTH1");
+        given(jwtProvider.getRoleTypeFromToken(anyString())).willReturn(RoleType.ADMIN);
+        given(userDetailsService.loadUserByUsername(anyString())).willReturn(mock(UserDetails.class));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/conference")
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("종료 날짜는 미래여야 합니다."));
+
+
+    }
+
+
+    @DisplayName("컨퍼런스 등록 시 위치 정보는 필수입니다.")
+    @Test
+    @WithMockUser(username = "AUTH1", roles = {"ADMIN"})
+    void registerConference_ExceptionOfLocation() throws Exception {
+        // given
+        ConferenceCreateRequest request = new ConferenceCreateRequest(
+                "카카오 대규모 IT 행사",
+                LocalDateTime.of(3000, 3, 18, 17, 0),
+                LocalDateTime.of(3025, 3, 18, 15, 0),
+                "  ",
+                "김승진",
+                "IT"
+        );
+
+        given(jwtProvider.validateToken(anyString())).willReturn(true);
+        given(jwtProvider.getEmailOrAuthCodeFromToken(anyString())).willReturn("AUTH1");
+        given(jwtProvider.getRoleTypeFromToken(anyString())).willReturn(RoleType.ADMIN);
+        given(userDetailsService.loadUserByUsername(anyString())).willReturn(mock(UserDetails.class));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/conference")
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("컨퍼런스 위치 정보는 필수입니다. 공백 이하는 불가능합니다."));
+
+
+    }
+
+    @DisplayName("컨퍼런스 등록 시 주최자명 입력은 필수입니다.")
+    @Test
+    @WithMockUser(username = "AUTH1", roles = {"ADMIN"})
+    void registerConference_ExceptionOfOrganizer() throws Exception {
+        // given
+        ConferenceCreateRequest request = new ConferenceCreateRequest(
+                "카카오 대규모 IT 행사",
+                LocalDateTime.of(3000, 3, 18, 17, 0),
+                LocalDateTime.of(3025, 3, 18, 15, 0),
+                "Seoul, South Korea",
+                "  ",
+                "IT"
+        );
+
+        given(jwtProvider.validateToken(anyString())).willReturn(true);
+        given(jwtProvider.getEmailOrAuthCodeFromToken(anyString())).willReturn("AUTH1");
+        given(jwtProvider.getRoleTypeFromToken(anyString())).willReturn(RoleType.ADMIN);
+        given(userDetailsService.loadUserByUsername(anyString())).willReturn(mock(UserDetails.class));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/conference")
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("주최자명은 필수입니다. 공백 이하는 불가능합니다."));
+
+
+    }
+
+    @DisplayName("컨퍼런스 등록 시 유형 입력은 필수입니다.")
+    @Test
+    @WithMockUser(username = "AUTH1", roles = {"ADMIN"})
+    void registerConference_ExceptionOfType() throws Exception {
+        // given
+        ConferenceCreateRequest request = new ConferenceCreateRequest(
+                "카카오 대규모 IT 행사",
+                LocalDateTime.of(3000, 3, 18, 17, 0),
+                LocalDateTime.of(3025, 3, 18, 15, 0),
+                "Seoul, South Korea",
+                "홍길동",
+                "   "
+        );
+
+        given(jwtProvider.validateToken(anyString())).willReturn(true);
+        given(jwtProvider.getEmailOrAuthCodeFromToken(anyString())).willReturn("AUTH1");
+        given(jwtProvider.getRoleTypeFromToken(anyString())).willReturn(RoleType.ADMIN);
+        given(userDetailsService.loadUserByUsername(anyString())).willReturn(mock(UserDetails.class));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/conference")
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("컨퍼런스 유형은 필수입니다. 공백 이하는 불가능합니다."));
+
+
+    }
 
 }

--- a/src/test/java/com/synergy/backend/domain/conference/api/ConferenceControllerTest.java
+++ b/src/test/java/com/synergy/backend/domain/conference/api/ConferenceControllerTest.java
@@ -1,0 +1,93 @@
+package com.synergy.backend.domain.conference.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.synergy.backend.domain.conference.dto.requset.ConferenceCreateRequest;
+import com.synergy.backend.domain.conference.dto.response.ConferenceCreateResponse;
+import com.synergy.backend.domain.conference.service.ConferenceService;
+import com.synergy.backend.domain.member.entity.RoleType;
+import com.synergy.backend.global.security.CustomUserDetailsService;
+import com.synergy.backend.global.security.JwtProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ConferenceController.class)
+class ConferenceControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @MockitoBean
+    ConferenceService conferenceService;
+
+    @MockitoBean
+    JwtProvider jwtProvider;
+    @MockitoBean
+    CustomUserDetailsService userDetailsService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    /**
+     * [@MockitoBean 를 서비스 계층 이외에도 사용한 이유]
+     * JwtAuthenticationFilter 필터가 스프링 빈으로 등록되었기에 MockBean 처리가 필수입니다.
+     * 필터를 추가하는 방식에 스프링 빈으로 등록하면 컨트롤러 테스트 과정에서 따로 추가해줘야 할 거 같습니다.
+     * 스프링 시큐리티 빈에서 따로 주입해주는 방법도 있으니 추후, 확정해도 괜찮아 보입니다.
+     */
+
+    @DisplayName("컨퍼런스를 등록한다.")
+    @Test
+    @WithMockUser(username = "AUTH1", roles = {"ADMIN"})
+    void registerConference() throws Exception {
+        // given
+        ConferenceCreateRequest request = new ConferenceCreateRequest(
+                "Spring Boot Conference 2025",
+                LocalDateTime.of(2025, 6, 15, 10, 0),
+                LocalDateTime.of(2025, 6, 16, 18, 0),
+                "Seoul, South Korea",
+                "김승진",
+                "IT"
+        );
+        ConferenceCreateResponse response = new ConferenceCreateResponse(1L);
+
+        given(conferenceService.registerConference(request))
+                .willReturn(response);
+        given(jwtProvider.validateToken(anyString()))
+                .willReturn(true);
+        given(jwtProvider.getEmailOrAuthCodeFromToken(anyString()))
+                .willReturn("AUTH1");
+        given(jwtProvider.getRoleTypeFromToken(anyString()))
+                .willReturn(RoleType.ADMIN);
+        given(userDetailsService.loadUserByUsername(anyString()))
+                .willReturn(mock(UserDetails.class));
+
+
+        // when & then
+        mockMvc.perform(post("/api/v1/conference")
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.id").value(1L));
+
+
+    }
+
+
+}


### PR DESCRIPTION
## 개요
컨퍼런스 컨트롤러에 대한 MockMvc 테스트를 진행했습니다.
현재는 컨퍼런스 등록에 대해서만 구성되었고 수정은 추후 진행할 예정입니다.

테스트 구현 단계에서 빠른 검증을 위해 @WithMockUser를 사용했습니다. @WithMockUser은 구체 설정이 되지 않아 컨트롤러 메서드에 있는 CustomUserDetail 값 내부가 null 처리되어 핸들링하기 어려운 문제를 겪었습니다.
따라서 @CurrentUser 를 만들어서 principal의 username만 가져오는 형식으로 변경했습니다.

## 진행한 이슈
- close #51 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 진행 사항

