### PR TITLE
feat: 참가자 정보 읽기 기능

### DIFF
--- a/src/main/java/com/synergy/backend/domain/interest/repository/InterestRepository.java
+++ b/src/main/java/com/synergy/backend/domain/interest/repository/InterestRepository.java
@@ -1,5 +1,6 @@
 package com.synergy.backend.domain.interest.repository;
 
+import java.util.List;
 import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,5 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.synergy.backend.domain.interest.entity.Interest;
 
 public interface InterestRepository extends JpaRepository<Interest, Long> {
-	Set<Interest> findAllByCodeIn(Set<Integer> interestCodes);
+	List<Interest> findAllByCodeIn(Set<Integer> interestCodes);
 }

--- a/src/main/java/com/synergy/backend/domain/member/api/AttendeeController.java
+++ b/src/main/java/com/synergy/backend/domain/member/api/AttendeeController.java
@@ -1,6 +1,7 @@
 package com.synergy.backend.domain.member.api;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,7 +14,7 @@ import com.synergy.backend.domain.member.api.dto.resposne.InterestResponseDto;
 import com.synergy.backend.domain.member.api.dto.resposne.JobInfoResponseDto;
 import com.synergy.backend.domain.member.entity.RoleType;
 import com.synergy.backend.domain.member.exception.AccessDeniedException;
-import com.synergy.backend.domain.member.service.AttendeeServiceImpl;
+import com.synergy.backend.domain.member.service.AttendeeService;
 import com.synergy.backend.global.common.ApiResponse;
 import com.synergy.backend.global.security.CustomUserDetails;
 
@@ -21,13 +22,13 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/v1/attendee/onboarding")
+@RequestMapping("/api/v1/attendee")
 @RequiredArgsConstructor
 public class AttendeeController {
 
-	private final AttendeeServiceImpl attendeeService;
+	private final AttendeeService attendeeService;
 
-	@PatchMapping(path = "/interest")
+	@PatchMapping(path = "/onboarding/interest")
 	public ApiResponse<InterestResponseDto> addUserInterest(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@Valid @RequestBody InterestRequestDto request) {
@@ -44,7 +45,7 @@ public class AttendeeController {
 			200);
 	}
 
-	@PatchMapping(path = "/job-info")
+	@PatchMapping(path = "/onboarding/job-info")
 	public ApiResponse<JobInfoResponseDto> addJobInfo(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@Valid @RequestBody JobInfoRequestDto request) {
@@ -59,7 +60,7 @@ public class AttendeeController {
 		return ApiResponse.ok(null, 200);
 	}
 
-	@PatchMapping(path = "/job-info-details")
+	@PatchMapping(path = "/onboarding/job-info-details")
 	public ApiResponse<JobInfoResponseDto> addJobInfoDetails(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@Valid @RequestBody JobInfoDetailsRequestDto request) {
@@ -71,6 +72,19 @@ public class AttendeeController {
 			throw new AccessDeniedException();
 		}
 		attendeeService.addJobInfoDetails(identifier, request);
+		return ApiResponse.ok(null, 200);
+	}
+
+	@GetMapping(path = "/my")
+	public ApiResponse<?> getMyInformation(
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		String identifier = userDetails.getIdentifier();
+		return ApiResponse.ok(attendeeService.getMyInformation(identifier), 200);
+	}
+
+	@GetMapping(path = "/{attendeeId}")
+	public ApiResponse<?> getAttendeeInfoDetail() {
 		return ApiResponse.ok(null, 200);
 	}
 

--- a/src/main/java/com/synergy/backend/domain/member/api/AttendeeController.java
+++ b/src/main/java/com/synergy/backend/domain/member/api/AttendeeController.java
@@ -3,6 +3,7 @@ package com.synergy.backend.domain.member.api;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,8 +11,10 @@ import org.springframework.web.bind.annotation.RestController;
 import com.synergy.backend.domain.member.api.dto.request.InterestRequestDto;
 import com.synergy.backend.domain.member.api.dto.request.JobInfoDetailsRequestDto;
 import com.synergy.backend.domain.member.api.dto.request.JobInfoRequestDto;
+import com.synergy.backend.domain.member.api.dto.resposne.AttendeeInfoDetailResponseDto;
 import com.synergy.backend.domain.member.api.dto.resposne.InterestResponseDto;
 import com.synergy.backend.domain.member.api.dto.resposne.JobInfoResponseDto;
+import com.synergy.backend.domain.member.api.dto.resposne.MyInfoResponseDto;
 import com.synergy.backend.domain.member.entity.RoleType;
 import com.synergy.backend.domain.member.exception.AccessDeniedException;
 import com.synergy.backend.domain.member.service.AttendeeService;
@@ -76,16 +79,27 @@ public class AttendeeController {
 	}
 
 	@GetMapping(path = "/my")
-	public ApiResponse<?> getMyInformation(
+	public ApiResponse<MyInfoResponseDto> getMyInformation(
 		@AuthenticationPrincipal CustomUserDetails userDetails
 	) {
 		String identifier = userDetails.getIdentifier();
+		RoleType role = userDetails.getRole();
+
+		if (role != RoleType.ATTENDEE) {
+			throw new AccessDeniedException();
+		}
+
 		return ApiResponse.ok(attendeeService.getMyInformation(identifier), 200);
 	}
 
 	@GetMapping(path = "/{attendeeId}")
-	public ApiResponse<?> getAttendeeInfoDetail() {
-		return ApiResponse.ok(null, 200);
+	public ApiResponse<AttendeeInfoDetailResponseDto> getAttendeeInfoDetail(
+		@PathVariable Long attendeeId,
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		String identifier = userDetails.getIdentifier();
+		RoleType role = userDetails.getRole();
+		return ApiResponse.ok(attendeeService.getAttendeeInfoDetail(attendeeId, identifier, role), 200);
 	}
 
 }

--- a/src/main/java/com/synergy/backend/domain/member/api/dto/resposne/AttendeeInfoDetailResponseDto.java
+++ b/src/main/java/com/synergy/backend/domain/member/api/dto/resposne/AttendeeInfoDetailResponseDto.java
@@ -1,0 +1,43 @@
+package com.synergy.backend.domain.member.api.dto.resposne;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.synergy.backend.domain.member.entity.Attendee;
+import com.synergy.backend.domain.member.entity.details.BaseAttendeeDetailEnum;
+
+public record AttendeeInfoDetailResponseDto(
+	String name,
+	String jobName,
+	String experience,
+	String education,
+	String ageGroup,
+	String techStacks,
+	Set<String> desiredWorkRegion,
+	String selfIntroduction,
+	String information,
+	Set<String> workplaceSelectionFactors,
+	Set<String> preferredCorporateCultures
+) {
+	public static AttendeeInfoDetailResponseDto from(Attendee attendee) {
+		return new AttendeeInfoDetailResponseDto(
+			attendee.getName(),
+			attendee.getCurrentJobCategory().getName(),
+			attendee.getExperienceLevel().getDescription(),
+			attendee.getEducationLevel().getDescription(),
+			attendee.getAgeGroup().getDescription(),
+			attendee.getTechStacks(),
+			attendee.getDesiredWorkRegion()
+				.stream().map(BaseAttendeeDetailEnum::getDescription)
+				.collect(Collectors.toSet()),
+			attendee.getSelfIntroduction(),
+			attendee.getInformation(),
+			attendee.getWorkplaceSelectionFactors()
+				.stream().map(BaseAttendeeDetailEnum::getDescription)
+				.collect(Collectors.toSet()),
+			attendee.getPreferredCorporateCultures()
+				.stream().map(BaseAttendeeDetailEnum::getDescription)
+				.collect(Collectors.toSet())
+		);
+	}
+}

--- a/src/main/java/com/synergy/backend/domain/member/api/dto/resposne/AttendeeInfoDetailResponseDto.java
+++ b/src/main/java/com/synergy/backend/domain/member/api/dto/resposne/AttendeeInfoDetailResponseDto.java
@@ -1,5 +1,6 @@
 package com.synergy.backend.domain.member.api.dto.resposne;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -21,23 +22,23 @@ public record AttendeeInfoDetailResponseDto(
 ) {
 	public static AttendeeInfoDetailResponseDto from(Attendee attendee) {
 		return new AttendeeInfoDetailResponseDto(
-			attendee.getName(),
-			attendee.getCurrentJobCategory().getName(),
-			attendee.getExperienceLevel().getDescription(),
-			attendee.getEducationLevel().getDescription(),
-			attendee.getAgeGroup().getDescription(),
-			attendee.getTechStacks(),
-			attendee.getDesiredWorkRegion()
-				.stream().map(BaseAttendeeDetailEnum::getDescription)
-				.collect(Collectors.toSet()),
-			attendee.getSelfIntroduction(),
-			attendee.getInformation(),
-			attendee.getWorkplaceSelectionFactors()
-				.stream().map(BaseAttendeeDetailEnum::getDescription)
-				.collect(Collectors.toSet()),
-			attendee.getPreferredCorporateCultures()
-				.stream().map(BaseAttendeeDetailEnum::getDescription)
-				.collect(Collectors.toSet())
+			attendee.getName() != null ? attendee.getName() : "Unknown",
+			attendee.getCurrentJobCategory() != null ? attendee.getCurrentJobCategory().getName() : "Unknown",
+			attendee.getExperienceLevel() != null ? attendee.getExperienceLevel().getDescription() : "Unknown",
+			attendee.getEducationLevel() != null ? attendee.getEducationLevel().getDescription() : "Unknown",
+			attendee.getAgeGroup() != null ? attendee.getAgeGroup().getDescription() : "Unknown",
+			attendee.getTechStacks() != null ? attendee.getTechStacks() : "No tech stack specified",
+			convertEnumSetToDescriptions(attendee.getDesiredWorkRegion()),
+			attendee.getSelfIntroduction() != null ? attendee.getSelfIntroduction() : "No self introduction",
+			attendee.getInformation() != null ? attendee.getInformation() : "No additional information",
+			convertEnumSetToDescriptions(attendee.getWorkplaceSelectionFactors()),
+			convertEnumSetToDescriptions(attendee.getPreferredCorporateCultures())
 		);
+	}
+
+	private static Set<String> convertEnumSetToDescriptions(Set<? extends BaseAttendeeDetailEnum> enums) {
+		return (enums != null) ?
+			enums.stream().map(BaseAttendeeDetailEnum::getDescription).collect(Collectors.toSet()) :
+			Collections.emptySet();
 	}
 }

--- a/src/main/java/com/synergy/backend/domain/member/api/dto/resposne/MyInfoResponseDto.java
+++ b/src/main/java/com/synergy/backend/domain/member/api/dto/resposne/MyInfoResponseDto.java
@@ -4,16 +4,15 @@ import java.util.List;
 
 import com.synergy.backend.domain.member.entity.Attendee;
 import com.synergy.backend.domain.point.api.dto.PointResponseDto;
-import com.synergy.backend.domain.point.entity.Point;
 
 public record MyInfoResponseDto(
 	String name,
 	String membershipLevel,
 	Integer totalPoints,
-	List<Point> recentPoints,
+	List<PointResponseDto> recentPoints,
 	Boolean isHiringInterested
 ) {
-	public static MyInfoResponseDto from(Attendee attendee, List<Point> recentPoints) {
+	public static MyInfoResponseDto from(Attendee attendee, List<PointResponseDto> recentPoints) {
 		return new MyInfoResponseDto(
 			attendee.getName(),
 			attendee.getMembershipLevelType().name(),

--- a/src/main/java/com/synergy/backend/domain/member/api/dto/resposne/MyInfoResponseDto.java
+++ b/src/main/java/com/synergy/backend/domain/member/api/dto/resposne/MyInfoResponseDto.java
@@ -1,0 +1,25 @@
+package com.synergy.backend.domain.member.api.dto.resposne;
+
+import java.util.List;
+
+import com.synergy.backend.domain.member.entity.Attendee;
+import com.synergy.backend.domain.point.api.dto.PointResponseDto;
+import com.synergy.backend.domain.point.entity.Point;
+
+public record MyInfoResponseDto(
+	String name,
+	String membershipLevel,
+	Integer totalPoints,
+	List<Point> recentPoints,
+	Boolean isHiringInterested
+) {
+	public static MyInfoResponseDto from(Attendee attendee, List<Point> recentPoints) {
+		return new MyInfoResponseDto(
+			attendee.getName(),
+			attendee.getMembershipLevelType().name(),
+			attendee.getTotalPoints(),
+			recentPoints,
+			attendee.isHiringInterested()
+		);
+	}
+}

--- a/src/main/java/com/synergy/backend/domain/member/entity/Attendee.java
+++ b/src/main/java/com/synergy/backend/domain/member/entity/Attendee.java
@@ -18,6 +18,7 @@ import com.synergy.backend.domain.member.entity.details.PreferredCorporateCultur
 import com.synergy.backend.domain.member.entity.details.RegionType;
 import com.synergy.backend.domain.member.entity.details.WorkplaceSelectionFactor;
 import com.synergy.backend.domain.point.entity.Point;
+import com.synergy.backend.domain.session.entity.AttendeeSession;
 import com.synergy.backend.global.common.BaseEntity;
 
 import jakarta.persistence.CascadeType;

--- a/src/main/java/com/synergy/backend/domain/member/entity/details/BaseAttendeeDetailEnum.java
+++ b/src/main/java/com/synergy/backend/domain/member/entity/details/BaseAttendeeDetailEnum.java
@@ -13,5 +13,7 @@ public interface BaseAttendeeDetailEnum {
 
 	Integer getCode();
 
+	String getDescription();
+
 	Supplier<? extends RuntimeException> getExceptionSupplier();
 }

--- a/src/main/java/com/synergy/backend/domain/member/service/AttendeeService.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AttendeeService.java
@@ -5,11 +5,13 @@ import java.util.Set;
 import com.synergy.backend.domain.interest.entity.Interest;
 import com.synergy.backend.domain.member.api.dto.request.JobInfoDetailsRequestDto;
 import com.synergy.backend.domain.member.api.dto.request.JobInfoRequestDto;
-import com.synergy.backend.domain.member.entity.Attendee;
+import com.synergy.backend.domain.member.api.dto.resposne.MyInfoResponseDto;
 
 public interface AttendeeService {
 
 	Set<Interest> addInterests(String email, Set<Integer> interestCodes);
 	void addJobInfo(String email, JobInfoRequestDto request);
 	void addJobInfoDetails(String email, JobInfoDetailsRequestDto request);
+
+	MyInfoResponseDto getMyInformation(String identifier);
 }

--- a/src/main/java/com/synergy/backend/domain/member/service/AttendeeService.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AttendeeService.java
@@ -5,13 +5,19 @@ import java.util.Set;
 import com.synergy.backend.domain.interest.entity.Interest;
 import com.synergy.backend.domain.member.api.dto.request.JobInfoDetailsRequestDto;
 import com.synergy.backend.domain.member.api.dto.request.JobInfoRequestDto;
+import com.synergy.backend.domain.member.api.dto.resposne.AttendeeInfoDetailResponseDto;
 import com.synergy.backend.domain.member.api.dto.resposne.MyInfoResponseDto;
+import com.synergy.backend.domain.member.entity.RoleType;
 
 public interface AttendeeService {
 
 	Set<Interest> addInterests(String email, Set<Integer> interestCodes);
+
 	void addJobInfo(String email, JobInfoRequestDto request);
+
 	void addJobInfoDetails(String email, JobInfoDetailsRequestDto request);
 
 	MyInfoResponseDto getMyInformation(String identifier);
+
+	AttendeeInfoDetailResponseDto getAttendeeInfoDetail(Long attendeeId, String identifier, RoleType role);
 }

--- a/src/main/java/com/synergy/backend/domain/member/service/AttendeeServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AttendeeServiceImpl.java
@@ -2,9 +2,7 @@ package com.synergy.backend.domain.member.service;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -41,7 +39,6 @@ import com.synergy.backend.domain.point.api.dto.PointResponseDto;
 import com.synergy.backend.domain.point.entity.Point;
 import com.synergy.backend.domain.point.repository.PointRepository;
 import com.synergy.backend.domain.point.service.PointService;
-import com.synergy.backend.global.exception.BaseErrorException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -128,16 +125,13 @@ public class AttendeeServiceImpl implements AttendeeService {
 	public MyInfoResponseDto getMyInformation(String identifier) {
 		Attendee attendee = findAttendeeByEmail(identifier);
 
-		try {
-			List<Point> points = pointRepository.findRecentPointsByAttendeeId(attendee.getId());
-			List<PointResponseDto> recentPoints = points.stream()
-				.map(point -> PointResponseDto.from(point, pointService.getDetailsForPoint(point)))
-				.toList();
+		List<Point> points = pointRepository.findRecentPointsByAttendeeId(attendee.getId());
+		List<PointResponseDto> recentPoints = points.stream()
+			.map(point -> PointResponseDto.from(point, pointService.getDetailsForPoint(point)))
+			.toList();
 
-			return MyInfoResponseDto.from(attendee, recentPoints);
-		} catch (Exception e) {
-			throw new BaseErrorException(500, "db 접근 에러");
-		}
+		return MyInfoResponseDto.from(attendee, recentPoints);
+
 	}
 
 	/** 참가자 상세 정보 */
@@ -158,26 +152,22 @@ public class AttendeeServiceImpl implements AttendeeService {
 		return AttendeeInfoDetailResponseDto.from(attendee);
 	}
 
-	private Attendee findAttendeeById(Long attendeeId) {
-		return attendeeRepository.findById(attendeeId)
-			.orElseThrow(NotFoundUserException::new);
-	}
-
 	// 관심사 코드 검증
 	private Set<Interest> getValidInterests(Set<Integer> interestCodes) {
-		Map<Integer, Interest> interestMap = interestRepository.findAllByCodeIn(interestCodes)
-			.stream()
-			.collect(Collectors.toMap(Interest::getCode, Function.identity()));
+		List<Interest> interests = interestRepository.findAllByCodeIn(interestCodes);
 
-		if (interestMap.size() != interestCodes.size()) {
-			Set<Integer> notFoundCodes = interestCodes.stream()
-				.filter(code -> !interestMap.containsKey(code))
+		if (interests.size() != interestCodes.size()) {
+			Set<Integer> foundCodes = interests.stream()
+				.map(Interest::getCode)
 				.collect(Collectors.toSet());
+
+			Set<Integer> notFoundCodes = new HashSet<>(interestCodes);
+			notFoundCodes.removeAll(foundCodes);
 
 			throw new NotFoundInterestException("Not found interests: " + notFoundCodes);
 		}
 
-		return new HashSet<>(interestMap.values());
+		return new HashSet<>(interests);
 	}
 
 	// 현재 등록된 관심사 가져오기
@@ -206,6 +196,11 @@ public class AttendeeServiceImpl implements AttendeeService {
 	private JobCategory findJobCategoryByCode(Integer jobCode) {
 		return jobCategoryRepository.findByCode(jobCode)
 			.orElseThrow(NotFoundJobCategoryException::new);
+	}
+
+	private Attendee findAttendeeById(Long attendeeId) {
+		return attendeeRepository.findById(attendeeId)
+			.orElseThrow(NotFoundUserException::new);
 	}
 
 	private Attendee findAttendeeByEmail(String email) {

--- a/src/main/java/com/synergy/backend/domain/member/service/AttendeeServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AttendeeServiceImpl.java
@@ -1,7 +1,10 @@
 package com.synergy.backend.domain.member.service;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -125,13 +128,12 @@ public class AttendeeServiceImpl implements AttendeeService {
 	public MyInfoResponseDto getMyInformation(String identifier) {
 		Attendee attendee = findAttendeeByEmail(identifier);
 
-		List<Point> points = pointRepository.findRecentPointsByAttendeeId(attendee.getId());
-		List<PointResponseDto> recentPoints = points.stream()
-			.map(point -> PointResponseDto.from(point, pointService.getDetailsForPoint(point)))
-			.toList();
+		List<PointResponseDto> recentPoints = mapToPointResponseDto(
+			Optional.ofNullable(pointRepository.findRecentPointsByAttendeeId(attendee.getId()))
+				.orElse(Collections.emptyList())
+		);
 
 		return MyInfoResponseDto.from(attendee, recentPoints);
-
 	}
 
 	/** 참가자 상세 정보 */
@@ -150,6 +152,14 @@ public class AttendeeServiceImpl implements AttendeeService {
 		Attendee attendee = findAttendeeById(attendeeId);
 
 		return AttendeeInfoDetailResponseDto.from(attendee);
+	}
+
+	private List<PointResponseDto> mapToPointResponseDto(List<Point> points) {
+		return points.stream()
+			.map(point -> PointResponseDto.from(point,
+				Objects.requireNonNullElse(pointService.getDetailsForPoint(point), "기본 포인트 설명")
+			))
+			.toList();
 	}
 
 	// 관심사 코드 검증

--- a/src/main/java/com/synergy/backend/domain/member/service/AttendeeServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AttendeeServiceImpl.java
@@ -23,8 +23,10 @@ import com.synergy.backend.domain.job.exception.NotFoundJobCategoryException;
 import com.synergy.backend.domain.job.exception.NotFoundOccupationCategoryException;
 import com.synergy.backend.domain.member.api.dto.request.JobInfoDetailsRequestDto;
 import com.synergy.backend.domain.member.api.dto.request.JobInfoRequestDto;
+import com.synergy.backend.domain.member.api.dto.resposne.AttendeeInfoDetailResponseDto;
 import com.synergy.backend.domain.member.api.dto.resposne.MyInfoResponseDto;
 import com.synergy.backend.domain.member.entity.Attendee;
+import com.synergy.backend.domain.member.entity.RoleType;
 import com.synergy.backend.domain.member.entity.details.AgeGroup;
 import com.synergy.backend.domain.member.entity.details.BaseAttendeeDetailEnum;
 import com.synergy.backend.domain.member.entity.details.ConferenceParticipationPurpose;
@@ -32,6 +34,7 @@ import com.synergy.backend.domain.member.entity.details.EducationLevelType;
 import com.synergy.backend.domain.member.entity.details.ExperienceLevelType;
 import com.synergy.backend.domain.member.entity.details.PreferredCorporateCulture;
 import com.synergy.backend.domain.member.entity.details.WorkplaceSelectionFactor;
+import com.synergy.backend.domain.member.exception.AccessDeniedException;
 import com.synergy.backend.domain.member.exception.NotFoundUserException;
 import com.synergy.backend.domain.member.repository.AttendeeRepository;
 import com.synergy.backend.domain.point.api.dto.PointResponseDto;
@@ -119,6 +122,7 @@ public class AttendeeServiceImpl implements AttendeeService {
 		);
 	}
 
+	/** 내 정보 */
 	@Transactional(readOnly = true)
 	@Override
 	public MyInfoResponseDto getMyInformation(String identifier) {
@@ -134,7 +138,29 @@ public class AttendeeServiceImpl implements AttendeeService {
 		} catch (Exception e) {
 			throw new BaseErrorException(500, "db 접근 에러");
 		}
+	}
 
+	/** 참가자 상세 정보 */
+	@Transactional(readOnly = true)
+	@Override
+	public AttendeeInfoDetailResponseDto getAttendeeInfoDetail(Long attendeeId, String identifier, RoleType role) {
+
+		if (role == RoleType.ATTENDEE) {
+			Attendee loginUser = findAttendeeByEmail(identifier);
+
+			if (!loginUser.getId().equals(attendeeId)) {
+				throw new AccessDeniedException();
+			}
+		}
+
+		Attendee attendee = findAttendeeById(attendeeId);
+
+		return AttendeeInfoDetailResponseDto.from(attendee);
+	}
+
+	private Attendee findAttendeeById(Long attendeeId) {
+		return attendeeRepository.findById(attendeeId)
+			.orElseThrow(NotFoundUserException::new);
 	}
 
 	// 관심사 코드 검증

--- a/src/main/java/com/synergy/backend/domain/member/service/AttendeeServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AttendeeServiceImpl.java
@@ -34,8 +34,10 @@ import com.synergy.backend.domain.member.entity.details.PreferredCorporateCultur
 import com.synergy.backend.domain.member.entity.details.WorkplaceSelectionFactor;
 import com.synergy.backend.domain.member.exception.NotFoundUserException;
 import com.synergy.backend.domain.member.repository.AttendeeRepository;
+import com.synergy.backend.domain.point.api.dto.PointResponseDto;
 import com.synergy.backend.domain.point.entity.Point;
 import com.synergy.backend.domain.point.repository.PointRepository;
+import com.synergy.backend.domain.point.service.PointService;
 import com.synergy.backend.global.exception.BaseErrorException;
 
 import lombok.RequiredArgsConstructor;
@@ -50,6 +52,8 @@ public class AttendeeServiceImpl implements AttendeeService {
 	private final JobCategoryRepository jobCategoryRepository;
 	private final OccupationCategoryRepository occupationCategoryRepository;
 	private final PointRepository pointRepository;
+
+	private final PointService pointService;
 
 	/** 관심사 추가 */
 	@Transactional
@@ -121,7 +125,11 @@ public class AttendeeServiceImpl implements AttendeeService {
 		Attendee attendee = findAttendeeByEmail(identifier);
 
 		try {
-			List<Point> recentPoints = pointRepository.findRecentPointsByAttendeeId(attendee.getId());
+			List<Point> points = pointRepository.findRecentPointsByAttendeeId(attendee.getId());
+			List<PointResponseDto> recentPoints = points.stream()
+				.map(point -> PointResponseDto.from(point, pointService.getDetailsForPoint(point)))
+				.toList();
+
 			return MyInfoResponseDto.from(attendee, recentPoints);
 		} catch (Exception e) {
 			throw new BaseErrorException(500, "db 접근 에러");

--- a/src/main/java/com/synergy/backend/domain/member/service/AttendeeServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AttendeeServiceImpl.java
@@ -1,6 +1,7 @@
 package com.synergy.backend.domain.member.service;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -22,6 +23,7 @@ import com.synergy.backend.domain.job.exception.NotFoundJobCategoryException;
 import com.synergy.backend.domain.job.exception.NotFoundOccupationCategoryException;
 import com.synergy.backend.domain.member.api.dto.request.JobInfoDetailsRequestDto;
 import com.synergy.backend.domain.member.api.dto.request.JobInfoRequestDto;
+import com.synergy.backend.domain.member.api.dto.resposne.MyInfoResponseDto;
 import com.synergy.backend.domain.member.entity.Attendee;
 import com.synergy.backend.domain.member.entity.details.AgeGroup;
 import com.synergy.backend.domain.member.entity.details.BaseAttendeeDetailEnum;
@@ -32,6 +34,9 @@ import com.synergy.backend.domain.member.entity.details.PreferredCorporateCultur
 import com.synergy.backend.domain.member.entity.details.WorkplaceSelectionFactor;
 import com.synergy.backend.domain.member.exception.NotFoundUserException;
 import com.synergy.backend.domain.member.repository.AttendeeRepository;
+import com.synergy.backend.domain.point.entity.Point;
+import com.synergy.backend.domain.point.repository.PointRepository;
+import com.synergy.backend.global.exception.BaseErrorException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -44,6 +49,7 @@ public class AttendeeServiceImpl implements AttendeeService {
 	private final AttendeeInterestRepository attendeeInterestRepository;
 	private final JobCategoryRepository jobCategoryRepository;
 	private final OccupationCategoryRepository occupationCategoryRepository;
+	private final PointRepository pointRepository;
 
 	/** 관심사 추가 */
 	@Transactional
@@ -107,6 +113,20 @@ public class AttendeeServiceImpl implements AttendeeService {
 			convertToEnumSet(
 				request.conferencePurposeCodes(), ConferenceParticipationPurpose.class)
 		);
+	}
+
+	@Transactional(readOnly = true)
+	@Override
+	public MyInfoResponseDto getMyInformation(String identifier) {
+		Attendee attendee = findAttendeeByEmail(identifier);
+
+		try {
+			List<Point> recentPoints = pointRepository.findRecentPointsByAttendeeId(attendee.getId());
+			return MyInfoResponseDto.from(attendee, recentPoints);
+		} catch (Exception e) {
+			throw new BaseErrorException(500, "db 접근 에러");
+		}
+
 	}
 
 	// 관심사 코드 검증

--- a/src/main/java/com/synergy/backend/domain/point/repository/PointRepository.java
+++ b/src/main/java/com/synergy/backend/domain/point/repository/PointRepository.java
@@ -3,9 +3,18 @@ package com.synergy.backend.domain.point.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import com.synergy.backend.domain.point.api.dto.PointResponseDto;
 import com.synergy.backend.domain.point.entity.Point;
 
 public interface PointRepository extends JpaRepository<Point, Long> {
 	List<Point> findByAttendeeIdOrderByCreatedTimeDesc(Long attendeeId);
+
+	@Query("SELECT p FROM Point p " +
+		"WHERE p.attendee.id = :attendeeId " +
+		"ORDER BY p.createdTime DESC " +
+		"LIMIT 3")
+	List<Point> findRecentPointsByAttendeeId(@Param("attendeeId") Long attendeeId);
 }

--- a/src/main/java/com/synergy/backend/domain/point/service/PointService.java
+++ b/src/main/java/com/synergy/backend/domain/point/service/PointService.java
@@ -22,4 +22,6 @@ public interface PointService {
 	void addSignupPoint(Long attendeeId);
 
 	List<PointResponseDto> getPointResponses(Long attendeeId);
+
+	String getDetailsForPoint(Point point);
 }

--- a/src/main/java/com/synergy/backend/domain/point/service/PointServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/point/service/PointServiceImpl.java
@@ -111,7 +111,8 @@ public class PointServiceImpl implements PointService {
 
 	}
 
-	private String getDetailsForPoint(Point point) {
+	@Override
+	public String getDetailsForPoint(Point point) {
 		return switch (point.getPointType()) {
 			case BOOTH_VISIT -> {
 				if (point.getBoothId() != null) {

--- a/src/test/java/com/synergy/backend/domain/member/service/AttendeeServiceImplTest.java
+++ b/src/test/java/com/synergy/backend/domain/member/service/AttendeeServiceImplTest.java
@@ -1,6 +1,16 @@
 package com.synergy.backend.domain.member.service;
 
+import static org.assertj.core.api.AssertionsForInterfaceTypes.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -10,8 +20,16 @@ import com.synergy.backend.domain.interest.repository.AttendeeInterestRepository
 import com.synergy.backend.domain.interest.repository.InterestRepository;
 import com.synergy.backend.domain.job.JobCategoryRepository;
 import com.synergy.backend.domain.job.OccupationCategoryRepository;
+import com.synergy.backend.domain.member.api.dto.resposne.AttendeeInfoDetailResponseDto;
+import com.synergy.backend.domain.member.api.dto.resposne.MyInfoResponseDto;
+import com.synergy.backend.domain.member.entity.Admin;
 import com.synergy.backend.domain.member.entity.Attendee;
+import com.synergy.backend.domain.member.entity.RoleType;
 import com.synergy.backend.domain.member.repository.AttendeeRepository;
+import com.synergy.backend.domain.point.entity.Point;
+import com.synergy.backend.domain.point.entity.PointType;
+import com.synergy.backend.domain.point.repository.PointRepository;
+import com.synergy.backend.domain.point.service.PointService;
 
 @ExtendWith(MockitoExtension.class)
 class AttendeeServiceImplTest {
@@ -26,16 +44,73 @@ class AttendeeServiceImplTest {
 	private JobCategoryRepository jobCategoryRepository;
 	@Mock
 	private OccupationCategoryRepository occupationCategoryRepository;
+	@Mock
+	private PointRepository pointRepository;
+	@Mock
+	private PointService pointService;
 
 	@InjectMocks
 	private AttendeeServiceImpl attendeeService;
 
 	private Attendee attendee;
+	private Attendee attendee2;
+	private Admin admin;
 
 	@BeforeEach
 	void setUp() {
 		attendee = Attendee.of("email@example.com", "password", "Tester", "01012345678");
+		attendee2 = Attendee.of("email2@example.com", "password", "Tester2", "01012345678");
+		admin = Admin.of("ADMIN1234");
 	}
 
+	@DisplayName("관리자가 참가자 정보를 조회한다.")
+	@Test
+	void getAttendeeInfoDetailByAdmin() {
+		// given
+		when(attendeeRepository.findById(1L)).thenReturn(Optional.ofNullable(attendee));
 
+		// when
+		AttendeeInfoDetailResponseDto response = attendeeService.getAttendeeInfoDetail(1L, "ADMIN1234",
+			RoleType.ADMIN);
+
+		// then
+		assertThat(response).isNotNull();
+		assertEquals(attendee.getName(), response.name());
+	}
+
+	@DisplayName("참가자가 내 정보를 조회한다.")
+	@Test
+	void getMyInformation() {
+		// given
+		String identifier = "email@example.com";
+		List<Point> pointList = List.of(Point.of(PointType.SIGN_UP), Point.of(PointType.BOOTH_VISIT));
+
+		when(attendeeRepository.findByEmail(identifier)).thenReturn(Optional.of(attendee));
+		when(pointRepository.findRecentPointsByAttendeeId(attendee.getId())).thenReturn(pointList);
+
+		// when
+		MyInfoResponseDto response = attendeeService.getMyInformation(identifier);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.recentPoints()).hasSize(2);
+		assertEquals(attendee.getTotalPoints(), response.totalPoints());
+	}
+
+	@Test
+	@DisplayName("참가자가 포인트가 없어도 정보를 정상적으로 조회한다.")
+	void getMyInformation_NoPoints() {
+		// given
+		String identifier = "email@example.com";
+
+		when(attendeeRepository.findByEmail(identifier)).thenReturn(Optional.of(attendee));
+		when(pointRepository.findRecentPointsByAttendeeId(attendee.getId())).thenReturn(Collections.emptyList());
+
+		// when
+		MyInfoResponseDto response = attendeeService.getMyInformation(identifier);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.recentPoints()).isEmpty();
+	}
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
참가자 정보 읽기 기능 추가

## 진행한 이슈
- close #56 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 진행 사항
이슈를 해결하기 위해 진행했던 사항들을 구체적으로 알려주세요.

**API 기능 추가**
1. GET `/api/v1/attendee/my` 
참가자 마이페이지 정보를 읽어오는 기능입니다.

2. GET `/api/v1/attendee/{attendeeId}`
참가자 상세 정보를 읽어오는 기능입니다.
관리자, 채용담당자는 모든 access 가능하고 참가자의 경우 본인만 확인 가능합니다.


**Test Code 작성**
<img width="376" alt="image" src="https://github.com/user-attachments/assets/6f3a172f-098b-49a3-9e91-7ae32989c56f" />
간단하게만 테스트코드 작성하였습니다.