### PR TITLE
test : 채용담당자 목록 조회

### DIFF
--- a/src/main/java/com/synergy/backend/domain/member/api/RecruiterController.java
+++ b/src/main/java/com/synergy/backend/domain/member/api/RecruiterController.java
@@ -84,7 +84,7 @@ public class RecruiterController {
 			페이징 처리를 통해 응답을 분할하여 제공합니다.
 			"""
 	)
-	@PreAuthorize("hasRole('RECRUITER')")
+	@PreAuthorize("hasRole('RECRUITER') or hasRole('ADMIN')")
 	@GetMapping("/{id}/attendees")
 	public ApiResponse<AttendeeListResponse> getAttendees(
 		@Parameter(description = "페이징 처리 정보 (기본: page=0, size=20)") @PageableDefault(page = 0, size = 20) Pageable pageable,

--- a/src/main/java/com/synergy/backend/domain/member/api/dto/AttendeeFilterRequest.java
+++ b/src/main/java/com/synergy/backend/domain/member/api/dto/AttendeeFilterRequest.java
@@ -7,15 +7,15 @@ import java.util.List;
 
 @Builder
 public record AttendeeFilterRequest(
-        List<String> occupations,
+        List<String> desiredOccupations,
         String educationLevel,
         String ageGroup,
         String experienceLevel,
         List<String> regions
 ) {
-    public static AttendeeFilterRequest of(List<String> occupations, String educationLevel, String ageGroup, String experienceLevel, List<String> regions) {
+    public static AttendeeFilterRequest of(List<String> desiredOccupations, String educationLevel, String ageGroup, String experienceLevel, List<String> regions) {
         return AttendeeFilterRequest.builder()
-                .occupations(occupations)
+                .desiredOccupations(desiredOccupations)
                 .educationLevel(educationLevel)
                 .ageGroup(ageGroup)
                 .experienceLevel(experienceLevel)

--- a/src/main/java/com/synergy/backend/domain/member/entity/Attendee.java
+++ b/src/main/java/com/synergy/backend/domain/member/entity/Attendee.java
@@ -1,262 +1,254 @@
 package com.synergy.backend.domain.member.entity;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import com.synergy.backend.domain.conference.entity.Conference;
 import com.synergy.backend.domain.interest.entity.AttendeeInterest;
 import com.synergy.backend.domain.job.JobGroup;
 import com.synergy.backend.domain.job.JobPosition;
-import com.synergy.backend.domain.member.entity.details.AgeGroup;
-import com.synergy.backend.domain.member.entity.details.ConferenceParticipationPurpose;
-import com.synergy.backend.domain.member.entity.details.EducationLevelType;
-import com.synergy.backend.domain.member.entity.details.ExperienceLevelType;
-import com.synergy.backend.domain.member.entity.details.MembershipLevelType;
-import com.synergy.backend.domain.member.entity.details.PreferredCorporateCulture;
-import com.synergy.backend.domain.member.entity.details.RegionType;
-import com.synergy.backend.domain.member.entity.details.WorkplaceSelectionFactor;
+import com.synergy.backend.domain.member.entity.details.*;
 import com.synergy.backend.domain.point.entity.Point;
 import com.synergy.backend.domain.session.entity.AttendeeSession;
 import com.synergy.backend.global.common.BaseEntity;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(
-	indexes = {
-		@Index(name = "idx_total_points", columnList = "total_points DESC")
-	})
+        indexes = {
+                @Index(name = "idx_total_points", columnList = "total_points DESC")
+        })
 public class Attendee extends BaseEntity implements User {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "attendee_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "attendee_id")
+    private Long id;
 
-	@Column(unique = true, nullable = false)
-	private String email;
+    @Column(unique = true, nullable = false)
+    private String email;
 
-	@Column(nullable = false)
-	private String password;
+    @Column(nullable = false)
+    private String password;
 
-	@Column(nullable = false, length = 25)
-	private String name;
+    @Column(nullable = false, length = 25)
+    private String name;
 
-	@Column(nullable = false)
-	private String phone;
+    @Column(nullable = false)
+    private String phone;
 
-	// 현재 포인트 합계
-	@Column(nullable = false)
-	private int totalPoints = 0;
+    // 현재 포인트 합계
+    @Column(nullable = false)
+    private int totalPoints = 0;
 
-	// 등급
-	@Column(nullable = false)
-	@Enumerated(EnumType.STRING)
-	private MembershipLevelType membershipLevelType = MembershipLevelType.DEFAULT;
+    // 등급
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private MembershipLevelType membershipLevelType = MembershipLevelType.DEFAULT;
 
-	@OneToMany(mappedBy = "attendee", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<Point> points = new ArrayList<>();
+    @OneToMany(mappedBy = "attendee", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Point> points = new ArrayList<>();
 
-	/*------Job Info------*/
-	// 현재 직군
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "current_job_group_id")
-	private JobGroup currentJobGroup;
+    /*------Job Info------*/
+    // 현재 직군
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "current_job_group_id")
+    private JobGroup currentJobGroup;
 
-	// 현재 직무
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "current_job_position_id")
-	private JobPosition currentJobPosition;
+    // 현재 직무
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "current_job_position_id")
+    private JobPosition currentJobPosition;
 
-	// 채용 희망여부
-	private Boolean isHiringInterested = false;
+    // 채용 희망여부
+    private Boolean isHiringInterested = false;
 
-	/*------Job Info Details------*/
-	// 희망 직무
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "desired_job_group_id")
-	private JobGroup desiredJobGroup;
+    /*------Job Info Details------*/
+    // 희망 직무
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "desired_job_group_id")
+    private JobGroup desiredJobGroup;
 
-	// 희망 직무
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "desired_job_position_id")
-	private JobPosition desiredJobPosition;
+    // 희망 직무
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "desired_job_position_id")
+    private JobPosition desiredJobPosition;
 
-	// 학력
-	@Enumerated(EnumType.STRING)
-	private EducationLevelType educationLevel;
+    // 학력
+    @Enumerated(EnumType.STRING)
+    private EducationLevelType educationLevel;
 
-	// 연령대
-	@Enumerated(EnumType.STRING)
-	private AgeGroup ageGroup;
+    // 연령대
+    @Enumerated(EnumType.STRING)
+    private AgeGroup ageGroup;
 
-	// 보유기술
-	private String techStacks;
+    // 보유기술
+    private String techStacks;
 
-	// 경력
-	@Enumerated(EnumType.STRING)
-	private ExperienceLevelType experienceLevel;
+    // 경력
+    @Enumerated(EnumType.STRING)
+    private ExperienceLevelType experienceLevel;
 
-	// 희망 근무 지역
-	@ElementCollection
-	@CollectionTable(name = "attendee_desired_work_region",
-		joinColumns = @JoinColumn(name = "attendee_id"))
-	@Enumerated(EnumType.ORDINAL)
-	private Set<RegionType> desiredWorkRegion = new HashSet<>();
+    // 희망 근무 지역
+    @ElementCollection
+    @CollectionTable(name = "attendee_desired_work_region",
+            joinColumns = @JoinColumn(name = "attendee_id"))
+    @Enumerated(EnumType.ORDINAL)
+    private Set<RegionType> desiredWorkRegion = new HashSet<>();
 
-	// 자기소개서
-	@Column(length = 1000)
-	private String selfIntroduction;
+    // 자기소개서
+    @Column(length = 1000)
+    private String selfIntroduction;
 
-	// 증명사진
-	private String profilePhotoUrl;
+    // 증명사진
+    private String profilePhotoUrl;
 
-	// 경험 및 기타 정보
-	private String information;
+    // 경험 및 기타 정보
+    private String information;
 
-	// 직장 선택 요소
-	@ElementCollection
-	@CollectionTable(name = "attendee_workplace_selection_factors",
-		joinColumns = @JoinColumn(name = "attendee_id"))
-	@Enumerated(EnumType.ORDINAL)
-	private Set<WorkplaceSelectionFactor> workplaceSelectionFactors = new HashSet<>();
+    // 직장 선택 요소
+    @ElementCollection
+    @CollectionTable(name = "attendee_workplace_selection_factors",
+            joinColumns = @JoinColumn(name = "attendee_id"))
+    @Enumerated(EnumType.ORDINAL)
+    private Set<WorkplaceSelectionFactor> workplaceSelectionFactors = new HashSet<>();
 
-	// 선호하는 기업 문화
-	@ElementCollection
-	@CollectionTable(name = "attendee_preferred_corporate_cultures",
-		joinColumns = @JoinColumn(name = "attendee_id"))
-	@Enumerated(EnumType.ORDINAL)
-	private Set<PreferredCorporateCulture> preferredCorporateCultures = new HashSet<>();
+    // 선호하는 기업 문화
+    @ElementCollection
+    @CollectionTable(name = "attendee_preferred_corporate_cultures",
+            joinColumns = @JoinColumn(name = "attendee_id"))
+    @Enumerated(EnumType.ORDINAL)
+    private Set<PreferredCorporateCulture> preferredCorporateCultures = new HashSet<>();
 
-	// 컨퍼런스 참여 목적
-	@ElementCollection
-	@CollectionTable(name = "attendee_conference_participation_purposes",
-		joinColumns = @JoinColumn(name = "attendee_id"))
-	@Enumerated(EnumType.ORDINAL)
-	private Set<ConferenceParticipationPurpose> conferenceParticipationPurposes = new HashSet<>();
+    // 컨퍼런스 참여 목적
+    @ElementCollection
+    @CollectionTable(name = "attendee_conference_participation_purposes",
+            joinColumns = @JoinColumn(name = "attendee_id"))
+    @Enumerated(EnumType.ORDINAL)
+    private Set<ConferenceParticipationPurpose> conferenceParticipationPurposes = new HashSet<>();
 
-	// 참가자-관심분야
-	@OneToMany(mappedBy = "attendee", cascade = CascadeType.ALL, orphanRemoval = true)
-	private Set<AttendeeInterest> attendeeInterests;
+    // 참가자-관심분야
+    @OneToMany(mappedBy = "attendee", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<AttendeeInterest> attendeeInterests;
 
-	// 컨퍼런스
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "conference_id")
-	private Conference conference;
+    // 컨퍼런스
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "conference_id")
+    private Conference conference;
 
-	@OneToMany(mappedBy = "attendee", cascade = CascadeType.ALL)
-	private List<AttendeeSession> attendeeSessions = new ArrayList<>();
+    @OneToMany(mappedBy = "attendee", cascade = CascadeType.ALL)
+    private List<AttendeeSession> attendeeSessions = new ArrayList<>();
 
-	@Builder
-	private Attendee(String password, String name, String phone, String email) {
-		this.password = password;
-		this.name = name;
-		this.phone = phone;
-		this.email = email;
-	}
+    @Builder
+    private Attendee(String password, String name, String phone, String email) {
+        this.password = password;
+        this.name = name;
+        this.phone = phone;
+        this.email = email;
+    }
 
-	public static Attendee of(String email, String encodedPassword, String name, String phone) {
-		return Attendee.builder()
-			.email(email)
-			.password(encodedPassword)
-			.name(name)
-			.phone(phone)
-			.build();
-	}
+    public static Attendee of(String email, String encodedPassword, String name, String phone) {
+        return Attendee.builder()
+                .email(email)
+                .password(encodedPassword)
+                .name(name)
+                .phone(phone)
+                .build();
+    }
 
-	@Override
-	public Long getId() {
-		return this.id;
-	}
+    @Override
+    public Long getId() {
+        return this.id;
+    }
 
-	@Override
-	public RoleType getRole() {
-		return RoleType.ATTENDEE;
-	}
+    @Override
+    public RoleType getRole() {
+        return RoleType.ATTENDEE;
+    }
 
-	@Override
-	public String getIdentifier() {
-		return this.email;
-	}
+    @Override
+    public String getIdentifier() {
+        return this.email;
+    }
 
-	public void updateJobInfo(JobPosition jobPosition, JobGroup jobGroup,
-		Boolean isHiringInterested) {
-		this.currentJobPosition = jobPosition;
-		this.currentJobGroup = jobGroup;
-		this.isHiringInterested = isHiringInterested;
-	}
+    public void updateJobInfo(JobPosition jobPosition, JobGroup jobGroup,
+                              Boolean isHiringInterested) {
+        this.currentJobPosition = jobPosition;
+        this.currentJobGroup = jobGroup;
+        this.isHiringInterested = isHiringInterested;
+    }
 
-	public void updateJobInfoDetails(
-		JobGroup desiredJobGroup,
-		JobPosition desiredJobPosition,
-		EducationLevelType educationLevel,
-		AgeGroup ageGroup,
-		String techStacks,
-		ExperienceLevelType experienceLevel,
-		String selfIntroduction,
-		String profilePhotoUrl,
-		String information,
-		Set<WorkplaceSelectionFactor> workplaceSelectionFactors,
-		Set<PreferredCorporateCulture> preferredCorporateCultures,
-		Set<ConferenceParticipationPurpose> conferenceParticipationPurposes
-	) {
-		this.desiredJobGroup = desiredJobGroup;
-		this.desiredJobPosition = desiredJobPosition;
-		this.educationLevel = educationLevel;
-		this.ageGroup = ageGroup;
-		this.techStacks = techStacks;
-		this.experienceLevel = experienceLevel;
-		this.selfIntroduction = selfIntroduction;
-		this.profilePhotoUrl = profilePhotoUrl;
-		this.information = information;
-		this.attendeeInterests =
-			attendeeInterests != null ? attendeeInterests : new HashSet<>();
-		this.workplaceSelectionFactors =
-			workplaceSelectionFactors != null ? workplaceSelectionFactors : new HashSet<>();
-		this.preferredCorporateCultures =
-			preferredCorporateCultures != null ? preferredCorporateCultures : new HashSet<>();
-		this.conferenceParticipationPurposes =
-			conferenceParticipationPurposes != null ? conferenceParticipationPurposes : new HashSet<>();
-	}
+    public void updateJobInfoDetails(
+            JobGroup desiredJobGroup,
+            JobPosition desiredJobPosition,
+            EducationLevelType educationLevel,
+            AgeGroup ageGroup,
+            String techStacks,
+            ExperienceLevelType experienceLevel,
+            String selfIntroduction,
+            String profilePhotoUrl,
+            String information,
+            Set<WorkplaceSelectionFactor> workplaceSelectionFactors,
+            Set<PreferredCorporateCulture> preferredCorporateCultures,
+            Set<ConferenceParticipationPurpose> conferenceParticipationPurposes
+    ) {
+        this.desiredJobGroup = desiredJobGroup;
+        this.desiredJobPosition = desiredJobPosition;
+        this.educationLevel = educationLevel;
+        this.ageGroup = ageGroup;
+        this.techStacks = techStacks;
+        this.experienceLevel = experienceLevel;
+        this.selfIntroduction = selfIntroduction;
+        this.profilePhotoUrl = profilePhotoUrl;
+        this.information = information;
+        this.attendeeInterests =
+                attendeeInterests != null ? attendeeInterests : new HashSet<>();
+        this.workplaceSelectionFactors =
+                workplaceSelectionFactors != null ? workplaceSelectionFactors : new HashSet<>();
+        this.preferredCorporateCultures =
+                preferredCorporateCultures != null ? preferredCorporateCultures : new HashSet<>();
+        this.conferenceParticipationPurposes =
+                conferenceParticipationPurposes != null ? conferenceParticipationPurposes : new HashSet<>();
+    }
 
-	public void addPoint(Point point) {
-		points.add(point);
-		point.assignAttendee(this);
-	}
+    public void addPoint(Point point) {
+        points.add(point);
+        point.assignAttendee(this);
+    }
 
-	public void addTotalPoints(int point) {
-		this.totalPoints += point;
-		updateMembershipLevel();
-	}
+    @Override
+    public String toString() {
+        return "Attendee{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", currentJobPosition=" + currentJobPosition.getName() +
+                ", isHiringInterested=" + isHiringInterested +
+                ", educationLevel=" + educationLevel.getDescription() +
+                ", desiredJobPosition=" + desiredJobPosition.getName() +
+                ", ageGroup=" + ageGroup.getDescription() +
+                ", experienceLevel=" + experienceLevel.getDescription() +
+                ", desiredWorkRegion=" + desiredWorkRegion.toString() +
+                '}';
+    }
 
-	private void updateMembershipLevel() {
-		this.membershipLevelType = MembershipLevelType.getMembershipLevel(this.totalPoints);
-	}
+    public void addTotalPoints(int point) {
+        this.totalPoints += point;
+        updateMembershipLevel();
+    }
 
-	public void updatePassword(String newEncodePassword) {
-		this.password = newEncodePassword;
-	}
+    private void updateMembershipLevel() {
+        this.membershipLevelType = MembershipLevelType.getMembershipLevel(this.totalPoints);
+    }
+
+    public void updatePassword(String newEncodePassword) {
+        this.password = newEncodePassword;
+    }
 }

--- a/src/main/java/com/synergy/backend/domain/member/repository/AttendeeRepositoryImpl.java
+++ b/src/main/java/com/synergy/backend/domain/member/repository/AttendeeRepositoryImpl.java
@@ -1,19 +1,5 @@
 package com.synergy.backend.domain.member.repository;
 
-import static com.synergy.backend.domain.job.QJobPosition.*;
-import static com.synergy.backend.domain.member.entity.QAttendee.*;
-import static com.synergy.backend.domain.member.entity.QRecruiterAttendeeLike.*;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
-
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -24,91 +10,103 @@ import com.synergy.backend.domain.member.entity.details.AgeGroup;
 import com.synergy.backend.domain.member.entity.details.EducationLevelType;
 import com.synergy.backend.domain.member.entity.details.ExperienceLevelType;
 import com.synergy.backend.domain.member.entity.details.RegionType;
-
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.synergy.backend.domain.job.QJobPosition.jobPosition;
+import static com.synergy.backend.domain.member.entity.QAttendee.attendee;
+import static com.synergy.backend.domain.member.entity.QRecruiterAttendeeLike.recruiterAttendeeLike;
 
 @RequiredArgsConstructor
 public class AttendeeRepositoryImpl implements AttendeeRepositoryCustom {
 
-	private static final Logger log = LoggerFactory.getLogger(AttendeeRepositoryImpl.class);
-	private final JPAQueryFactory queryFactory;
+    private static final Logger log = LoggerFactory.getLogger(AttendeeRepositoryImpl.class);
+    private final JPAQueryFactory queryFactory;
 
-	@Override
-	public Page<AttendeeSimpleResponseDto> searchPageAttendeesBy(Pageable pageable, Long recruiterId,
-		AttendeeFilterRequest requestCondition) {
+    @Override
+    public Page<AttendeeSimpleResponseDto> searchPageAttendeesBy(Pageable pageable, Long recruiterId,
+                                                                 AttendeeFilterRequest requestCondition) {
 
-		List<AttendeeSimpleResponseDto> content = queryFactory
-			.select(
-				new QAttendeeSimpleResponseDto(
-					attendee.id,
-					attendee.name,
-					attendee.profilePhotoUrl,
-					jobPosition.name,
-					attendee.experienceLevel,
-					attendee.techStacks,
-					new CaseBuilder()
-						.when(recruiterAttendeeLike.id.isNotNull()).then(true)
-						.otherwise(false)
-				)
-			).from(attendee)
-			.leftJoin(recruiterAttendeeLike)
-			.on(recruiterAttendeeLike.attendee.eq(attendee)
-				.and(recruiterAttendeeLike.recruiter.id.eq(recruiterId))) // 현재 로그인 리크루터의 좋아요 여부
-			.join(attendee.currentJobPosition, jobPosition)
-			.where(
-				occupationIn(requestCondition.occupations()),
-				educationEq(requestCondition.educationLevel()),
-				ageGroupEq(requestCondition.ageGroup()),
-				experienceEq(requestCondition.experienceLevel()),
-				desiredRegionIn(requestCondition.regions()),
-				attendee.isHiringInterested.eq(true)
-			)
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.fetch();
+        List<AttendeeSimpleResponseDto> content = queryFactory
+                .select(
+                        new QAttendeeSimpleResponseDto(
+                                attendee.id,
+                                attendee.name,
+                                attendee.profilePhotoUrl,
+                                jobPosition.name,
+                                attendee.experienceLevel,
+                                attendee.techStacks,
+                                new CaseBuilder()
+                                        .when(recruiterAttendeeLike.id.isNotNull()).then(true)
+                                        .otherwise(false)
+                        )
+                ).from(attendee)
+                .leftJoin(recruiterAttendeeLike)
+                .on(recruiterAttendeeLike.attendee.eq(attendee)
+                        .and(recruiterAttendeeLike.recruiter.id.eq(recruiterId))) // 현재 로그인 리크루터의 좋아요 여부
+                .join(attendee.desiredJobPosition, jobPosition)
+                .where(
+                        occupationIn(requestCondition.desiredOccupations()),
+                        educationEq(requestCondition.educationLevel()),
+                        ageGroupEq(requestCondition.ageGroup()),
+                        experienceEq(requestCondition.experienceLevel()),
+                        desiredRegionIn(requestCondition.regions()),
+                        attendee.isHiringInterested.eq(true)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
 
-		return new PageImpl<>(content, pageable, content.size());
-	}
+        return new PageImpl<>(content, pageable, content.size());
+    }
 
-	private BooleanExpression occupationIn(List<String> occupations) {
-		return (occupations == null || occupations.isEmpty()) ? null : attendee.currentJobPosition.name.in(occupations);
+    private BooleanExpression occupationIn(List<String> occupations) {
+        return (occupations == null || occupations.isEmpty()) ? null : attendee.currentJobPosition.name.in(occupations);
 
-	}
+    }
 
-	private BooleanExpression educationEq(String educationLevel) {
+    private BooleanExpression educationEq(String educationLevel) {
 
-		return Arrays.stream(EducationLevelType.values())
-			.filter(e -> e.getDescription().equals(educationLevel))
-			.findFirst()
-			.map(attendee.educationLevel::eq)
-			.orElse(null);
-	}
+        return Arrays.stream(EducationLevelType.values())
+                .filter(e -> e.getDescription().equals(educationLevel))
+                .findFirst()
+                .map(attendee.educationLevel::eq)
+                .orElse(null);
+    }
 
-	private BooleanExpression ageGroupEq(String ageGroup) {
+    private BooleanExpression ageGroupEq(String ageGroup) {
 
-		return Arrays.stream(AgeGroup.values())
-			.filter(e -> e.getDescription().equals(ageGroup))
-			.findFirst()
-			.map(attendee.ageGroup::eq)
-			.orElse(null);
-	}
+        return Arrays.stream(AgeGroup.values())
+                .filter(e -> e.getDescription().equals(ageGroup))
+                .findFirst()
+                .map(attendee.ageGroup::eq)
+                .orElse(null);
+    }
 
-	private BooleanExpression experienceEq(String experienceLevel) {
-		return Arrays.stream(ExperienceLevelType.values())
-			.filter(e -> e.getDescription().equals(experienceLevel))
-			.findFirst()
-			.map(attendee.experienceLevel::eq)
-			.orElse(null);
-	}
+    private BooleanExpression experienceEq(String experienceLevel) {
+        return Arrays.stream(ExperienceLevelType.values())
+                .filter(e -> e.getDescription().equals(experienceLevel))
+                .findFirst()
+                .map(attendee.experienceLevel::eq)
+                .orElse(null);
+    }
 
-	private BooleanExpression desiredRegionIn(List<String> regions) {
-		if (regions == null || regions.isEmpty())
-			return null;
+    private BooleanExpression desiredRegionIn(List<String> regions) {
+        if (regions == null || regions.isEmpty())
+            return null;
 
-		List<RegionType> types = Arrays.stream(RegionType.values())
-			.filter(r -> regions.contains(r.getDescription()))
-			.collect(Collectors.toList());
+        List<RegionType> types = Arrays.stream(RegionType.values())
+                .filter(r -> regions.contains(r.getDescription()))
+                .collect(Collectors.toList());
 
-		return types.isEmpty() ? null : attendee.desiredWorkRegion.any().in(types);
-	}
+        return types.isEmpty() ? null : attendee.desiredWorkRegion.any().in(types);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,10 +58,10 @@ mail:
     password: ${EMAIL_PASSWORD}
     port: 465
 
-#logging:
-#  level:
-#    org.hibernate.SQL: DEBUG  # ✅ SQL 로그를 DEBUG 수준으로 상세하게 출력
-#    org.hibernate.type.descriptor.sql: TRACE  # ✅ 바인딩된 파라미터도 함께 출력
+logging:
+  level:
+    org.hibernate.SQL: DEBUG  # ✅ SQL 로그를 DEBUG 수준으로 상세하게 출력
+    org.hibernate.type.descriptor.sql: TRACE  # ✅ 바인딩된 파라미터도 함께 출력
 ---
 jwt:
   secret: ${JWT_SECRET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -170,6 +170,9 @@ spring:
       max-file-size: 2MB
       max-request-size: 15MB
 
-
+  sql:
+    init:
+      mode: always
+      data-locations: classpath:data-test.sql
 
 

--- a/src/main/resources/data-test.sql
+++ b/src/main/resources/data-test.sql
@@ -1,0 +1,241 @@
+-- id값 테이블은 1부터, enum은 0부터
+---- 관심 분야
+INSERT INTO interest (name, code) VALUES ('데이터 분석 / AI', 101);
+INSERT INTO interest (name, code) VALUES ('클라우드 / DevOps', 102);
+INSERT INTO interest (name, code) VALUES ('소프트웨어 개발', 103);
+INSERT INTO interest (name, code) VALUES ('디자인', 104);
+INSERT INTO interest (name, code) VALUES ('정보 보안', 105);
+INSERT INTO interest (name, code) VALUES ('신기술 연구', 106);
+INSERT INTO interest (name, code) VALUES ('커리어 개발', 107);
+INSERT INTO interest (name, code) VALUES ('기획/운영', 108);
+
+-- 직군 (Job Group)
+INSERT INTO job_group (code, name) VALUES (1, '개발');
+INSERT INTO job_group (code, name) VALUES (2, '디자인');
+INSERT INTO job_group (code, name) VALUES (3, '기획/운영');
+INSERT INTO job_group (code, name) VALUES (4, '기타');
+
+-- 직무 (Job Position)
+INSERT INTO job_position (code, name, job_group_id) VALUES (101, '프론트엔드 개발자', 1);
+INSERT INTO job_position (code, name, job_group_id) VALUES (102, '백엔드 개발자', 1);
+INSERT INTO job_position (code, name, job_group_id) VALUES (103, '풀스텍 개발자', 1);
+INSERT INTO job_position (code, name, job_group_id) VALUES (104, 'AI/머신러닝 엔지니어', 1);
+INSERT INTO job_position (code, name, job_group_id) VALUES (105, '클라우드 엔지니어', 1);
+INSERT INTO job_position (code, name, job_group_id) VALUES (106, 'DevOps 엔지니어', 1);
+INSERT INTO job_position (code, name, job_group_id) VALUES (107, '데이터 엔지니어', 1);
+INSERT INTO job_position (code, name, job_group_id) VALUES (108, '모바일 앱 개발자', 1);
+INSERT INTO job_position (code, name, job_group_id) VALUES (109, '임베디드 시스템 개발자', 1);
+INSERT INTO job_position (code, name, job_group_id) VALUES (110, '블록체인 개발자', 1);
+
+-- 디자인 직군
+INSERT INTO job_position (code, name, job_group_id) VALUES (201, 'UI/UX 디자이너', 2);
+INSERT INTO job_position (code, name, job_group_id) VALUES (202, '그래픽 디자이너', 2);
+INSERT INTO job_position (code, name, job_group_id) VALUES (203, '웹디자이너', 2);
+
+-- 기획/운영 직군
+INSERT INTO job_position (code, name, job_group_id) VALUES (301, '프로젝트 매니저', 3);
+INSERT INTO job_position (code, name, job_group_id) VALUES (302, '데이터 분석가', 3);
+INSERT INTO job_position (code, name, job_group_id) VALUES (303, '마케터', 3);
+
+-- 기타 직군
+INSERT INTO job_position (code, name, job_group_id) VALUES (401, '학생', 4);
+INSERT INTO job_position (code, name, job_group_id) VALUES (402, '취업 준비', 4);
+INSERT INTO job_position (code, name, job_group_id) VALUES (403, '연구원', 4);
+INSERT INTO job_position (code, name, job_group_id) VALUES (499, '기타', 4);
+
+-- 관리자
+INSERT INTO admin (admin_auth_code) VALUES ('ADM12345');
+INSERT INTO admin (admin_auth_code) VALUES ('ADM67890');
+
+-- 채용 담당자
+INSERT INTO recruiter (recruiter_auth_code, company, responsibility, name) VALUES ('RC12345', 'CodeSphere', 'HR팀 매니저', '박수진');
+INSERT INTO recruiter (recruiter_auth_code, company, responsibility, name) VALUES ( 'RC67890', 'OpenStack Korea', 'HR팀 매니저', '김주은');
+
+-- 참가자 기본 데이터
+INSERT INTO attendee (email, password, name, phone, total_points, membership_level_type)
+VALUES
+    ('jiwon.kim@example.com', '$2a$10$aO4mzbreIOHJiJDgPaUtG.BS81l7i92I2.D2qkwvM5hvUB8BGBsk2', '김지원', '01012345678', 250, 'BRONZE'),
+    ('youngho.choi@example.com', '$2a$10$hashedpassword2', '최영호', '01056781234', 1200, 'GOLD'),
+    ('seoyeon.jung@example.com', '$2a$10$hashedpassword3', '정서연', '01055556666', 1200, 'GOLD'),
+    ('sihyung.park@example.com', '$2a$10$hashedpassword4', '박시형', '01077778888', 300, 'SILVER'),
+    ('dayoung.lee@example.com', '$2a$10$hashedpassword5', '이다영', '01099990000', 1500, 'GOLD'),
+    ('dahye.kim@example.com', '$2a$10$hashedpassword6', '김다혜', '01011112222', 50, 'DEFAULT');
+
+-- 김지원 (attendee_id = 1) → 수도권, 부산
+INSERT INTO attendee_desired_work_region (attendee_id, desired_work_region) VALUES (1, 0); -- CAPITAL_AREA
+INSERT INTO attendee_desired_work_region (attendee_id, desired_work_region) VALUES (1, 1); -- BUSAN
+
+-- 최영호 (attendee_id = 2) → 대구
+INSERT INTO attendee_desired_work_region (attendee_id, desired_work_region) VALUES (2, 2); -- DAEGU
+
+-- 정서연 (attendee_id = 3) → 대전, 세종
+INSERT INTO attendee_desired_work_region (attendee_id, desired_work_region) VALUES (3, 3); -- DAEJEON
+INSERT INTO attendee_desired_work_region (attendee_id, desired_work_region) VALUES (3, 6); -- SEJONG
+
+-- 박시형 (attendee_id = 4) → 강원, 전라
+INSERT INTO attendee_desired_work_region (attendee_id, desired_work_region) VALUES (4, 7); -- GANGWON
+INSERT INTO attendee_desired_work_region (attendee_id, desired_work_region) VALUES (4, 9); -- JEOLLA
+
+-- 이다영 (attendee_id = 5) → 경상, 제주
+INSERT INTO attendee_desired_work_region (attendee_id, desired_work_region) VALUES (5, 10); -- GYEONGSANG
+INSERT INTO attendee_desired_work_region (attendee_id, desired_work_region) VALUES (5, 11); -- JEJU
+
+-- 김다혜 (attendee_id = 6) → 울산, 충청
+INSERT INTO attendee_desired_work_region (attendee_id, desired_work_region) VALUES (6, 5); -- ULSAN
+INSERT INTO attendee_desired_work_region (attendee_id, desired_work_region) VALUES (6, 8); -- CHUNGCHEONG
+
+
+
+-- 참가자의 현재 직업 및 직무 업데이트
+UPDATE attendee
+SET
+is_hiring_interested = 1,
+current_job_position_id = 2,
+current_job_group_id = 1,
+desired_job_group_id = 1,
+self_introduction = '저는 최신 기술을 배우고 IT 업계에서 성장하기 위해 다양한 컨퍼런스와 개발 프로젝트에 참여해왔습니다. 컴퓨터공학 전공자로서 웹 애플리케이션 개발과 데이터베이스 설계 경험이 있으며, 협업과 문제 해결 역량을 갖추고 있습니다. 여러 해커톤과 오픈소스 프로젝트에 참여하며 실무 감각을 익혔고, 컨퍼런스를 통해 업계 트렌드를 학습하며 네트워킹을 적극적으로 활용해왔습니다. 앞으로 데이터 분석과 AI 기술을 활용하여 가치 있는 서비스를 개발하고, 변화하는 환경 속에서 끊임없이 성장하는 개발자가 되고 싶습니다. 이번 기회를 통해 실무 경험을 쌓으며, IT 업계에서 더욱 발전할 수 있도록 최선을 다하겠습니다.',
+tech_stacks = 'Java, AWS, Spring Boot, MySQL, Docker, JPA, github-actions, SonarQube, Redis, junit5, Mockito, Git',
+age_group = 'AGE_20_24',
+education_level = 2,
+experience_level = 1
+WHERE attendee_id = 1;
+
+UPDATE attendee
+SET
+is_hiring_interested = 1,
+tech_stacks = 'AWS',
+age_group = 'AGE_20_24',
+education_level = 2,
+experience_level = 2,
+current_job_position_id = 12,
+current_job_group_id = 2,
+desired_job_group_id = 2,
+self_introduction = '최신 사람입니다!'
+WHERE attendee_id = 2;
+
+UPDATE attendee
+SET
+is_hiring_interested = 1,
+tech_stacks = 'Ruby',
+age_group = 'AGE_25_29',
+education_level = 1,
+experience_level = 1,
+current_job_position_id = 11,
+current_job_group_id = 2,
+desired_job_group_id = 2,
+self_introduction = '사람입니다!'
+WHERE attendee_id = 3;
+
+UPDATE attendee
+SET
+is_hiring_interested = 1,
+tech_stacks = 'Go, C++',
+age_group = 'AGE_35_PLUS',
+education_level = 3,
+experience_level = 3,
+current_job_position_id = 1,
+current_job_group_id = 1,
+desired_job_group_id = 1,
+self_introduction = '혼자서 할 수 있는 개발자!'
+WHERE attendee_id = 4;
+
+UPDATE attendee
+SET
+is_hiring_interested = 1,
+tech_stacks = 'Go, C++',
+age_group = 'AGE_35_PLUS',
+education_level = 3,
+experience_level = 3,
+current_job_position_id = 1,
+current_job_group_id = 1,
+desired_job_group_id = 1,
+self_introduction = '혼자서 할 수 있는 개발자!'
+WHERE attendee_id = 5;
+
+UPDATE attendee
+SET
+is_hiring_interested = 1,
+tech_stacks = 'Git, Docker',
+age_group = 'AGE_30_34',
+education_level = 3,
+experience_level = 3,
+current_job_position_id = 1,
+current_job_group_id = 1,
+desired_job_group_id = 1,
+self_introduction = '100인 분 할 수 있는 개발자!'
+WHERE attendee_id = 6;
+
+-- 참가자의 관심 분야(Interest) 매핑
+INSERT INTO attendee_interest (attendee_id, interest_id)
+VALUES
+    (1, 1),
+    (1, 2),
+    (1, 3),
+    (2, 4),
+    (3, 5),
+    (4, 6),
+    (5, 7),
+    (6, 8);
+
+
+-- 채용담당자 좋아요 업데이트
+INSERT INTO recruiter_attendee_like (id, attendee_id, recruiter_id)
+    VALUES
+        (1, 1, 1),
+        (2, 2, 1),
+        (3, 3, 1),
+    (4, 1, 2),
+    (5, 2, 2);
+
+-- 참가자의 선호 기업 문화 업데이트
+INSERT INTO attendee_preferred_corporate_cultures (attendee_id, preferred_corporate_cultures)
+VALUES
+    (1, 0),
+    (1, 1),
+    (2, 2),
+    (3, 3),
+    (4, 4),
+    (5, 0),
+    (6, 1);
+
+-- 참가자의 컨퍼런스 참여 목적
+INSERT INTO attendee_conference_participation_purposes (attendee_id, conference_participation_purposes)
+VALUES
+    (1, 0),
+    (1, 1),
+    (2, 2),
+    (3, 3),
+    (4, 0),
+    (5, 2),
+    (6, 3);
+
+-- 직장 선택 요소
+INSERT INTO attendee_workplace_selection_factors (attendee_id, workplace_selection_factors)
+VALUES
+    (1, 0),
+    (1, 4),
+    (2, 1),
+    (3, 2),
+    (4, 3),
+    (5, 4),
+    (6, 0);
+
+
+
+-- 컨퍼런스
+INSERT INTO conference (start_date_time, end_date_time, organizer, name, type, location)
+VALUES
+    ('2025-09-15 09:00', '2025-09-16 18:00', 'FlowLink', 'F’LINK 2025', 'IT', '그랜드볼룸');
+
+-- 부스
+INSERT INTO booth (conference_id, company, name, description, location)
+VALUES
+    (1, 'CodeSphere', '클라우드서비스', ' 글로벌 IT 기업 CodeSphere에서 React 기반 프론트엔드 엔지니어와 클라우드 기반 백엔드 엔지니어를 채용합니다. TypeScript, Node.js, Kubernetes 경험자를 환영합니다.','C HALL');
+
+-- 세션
+INSERT INTO session (maximum, progress_date, conference_id, end_time, start_time, speaker_position, speaker, title, description, qr_key, qr_url, image_key, image_url, secret_code)
+VALUES
+    (250, '2025-09-15', 1, '2025-09-15 11:30', '2025-09-15 10:30', 'CTO', '김지혁', '최신 기술 동향', '빠르게 변화하는 IT 산업에서 최신 기술 동향을 파악하는 것은 기업의 경쟁력을 높이고 미래를 준비하는 데 필수적입니다. 기업의 CTO가 AI, 클라우드, Web3 등 주요 기술 트렌드와 산업 변화를 분석하고, 기업이 기술 혁신을 어떻게 주도할 수 있는지에 대한 전략과 인사이트를 제공합니다.', ' ', ' ', ' ', ' ', ' ');
+
+
+

--- a/src/main/resources/data-test.sql
+++ b/src/main/resources/data-test.sql
@@ -93,6 +93,7 @@ is_hiring_interested = 1,
 current_job_position_id = 2,
 current_job_group_id = 1,
 desired_job_group_id = 1,
+desired_job_position_id = 2,
 self_introduction = '저는 최신 기술을 배우고 IT 업계에서 성장하기 위해 다양한 컨퍼런스와 개발 프로젝트에 참여해왔습니다. 컴퓨터공학 전공자로서 웹 애플리케이션 개발과 데이터베이스 설계 경험이 있으며, 협업과 문제 해결 역량을 갖추고 있습니다. 여러 해커톤과 오픈소스 프로젝트에 참여하며 실무 감각을 익혔고, 컨퍼런스를 통해 업계 트렌드를 학습하며 네트워킹을 적극적으로 활용해왔습니다. 앞으로 데이터 분석과 AI 기술을 활용하여 가치 있는 서비스를 개발하고, 변화하는 환경 속에서 끊임없이 성장하는 개발자가 되고 싶습니다. 이번 기회를 통해 실무 경험을 쌓으며, IT 업계에서 더욱 발전할 수 있도록 최선을 다하겠습니다.',
 tech_stacks = 'Java, AWS, Spring Boot, MySQL, Docker, JPA, github-actions, SonarQube, Redis, junit5, Mockito, Git',
 age_group = 'AGE_20_24',
@@ -110,6 +111,7 @@ experience_level = 2,
 current_job_position_id = 12,
 current_job_group_id = 2,
 desired_job_group_id = 2,
+desired_job_position_id = 12,
 self_introduction = '최신 사람입니다!'
 WHERE attendee_id = 2;
 
@@ -123,6 +125,7 @@ experience_level = 1,
 current_job_position_id = 11,
 current_job_group_id = 2,
 desired_job_group_id = 2,
+desired_job_position_id = 10,
 self_introduction = '사람입니다!'
 WHERE attendee_id = 3;
 
@@ -136,6 +139,7 @@ experience_level = 3,
 current_job_position_id = 1,
 current_job_group_id = 1,
 desired_job_group_id = 1,
+desired_job_position_id = 2,
 self_introduction = '혼자서 할 수 있는 개발자!'
 WHERE attendee_id = 4;
 
@@ -149,6 +153,7 @@ experience_level = 3,
 current_job_position_id = 1,
 current_job_group_id = 1,
 desired_job_group_id = 1,
+desired_job_position_id = 2,
 self_introduction = '혼자서 할 수 있는 개발자!'
 WHERE attendee_id = 5;
 
@@ -162,6 +167,7 @@ experience_level = 3,
 current_job_position_id = 1,
 current_job_group_id = 1,
 desired_job_group_id = 1,
+desired_job_position_id = 2,
 self_introduction = '100인 분 할 수 있는 개발자!'
 WHERE attendee_id = 6;
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -89,80 +89,86 @@ INSERT INTO attendee_desired_work_region (attendee_id, desired_work_region) VALU
 -- 참가자의 현재 직업 및 직무 업데이트
 UPDATE attendee
 SET
-is_hiring_interested = 1,
-current_job_position_id = 2,
-current_job_group_id = 1,
-desired_job_group_id = 1,
-self_introduction = '저는 최신 기술을 배우고 IT 업계에서 성장하기 위해 다양한 컨퍼런스와 개발 프로젝트에 참여해왔습니다. 컴퓨터공학 전공자로서 웹 애플리케이션 개발과 데이터베이스 설계 경험이 있으며, 협업과 문제 해결 역량을 갖추고 있습니다. 여러 해커톤과 오픈소스 프로젝트에 참여하며 실무 감각을 익혔고, 컨퍼런스를 통해 업계 트렌드를 학습하며 네트워킹을 적극적으로 활용해왔습니다. 앞으로 데이터 분석과 AI 기술을 활용하여 가치 있는 서비스를 개발하고, 변화하는 환경 속에서 끊임없이 성장하는 개발자가 되고 싶습니다. 이번 기회를 통해 실무 경험을 쌓으며, IT 업계에서 더욱 발전할 수 있도록 최선을 다하겠습니다.',
-tech_stacks = 'Java, AWS, Spring Boot, MySQL, Docker, JPA, github-actions, SonarQube, Redis, junit5, Mockito, Git',
-age_group = 'AGE_20_24',
-education_level = 2,
-experience_level = 1
+    is_hiring_interested = 1,
+    current_job_position_id = 2,
+    current_job_group_id = 1,
+    desired_job_group_id = 1,
+    desired_job_position_id = 2,
+    self_introduction = '저는 최신 기술을 배우고 IT 업계에서 성장하기 위해 다양한 컨퍼런스와 개발 프로젝트에 참여해왔습니다. 컴퓨터공학 전공자로서 웹 애플리케이션 개발과 데이터베이스 설계 경험이 있으며, 협업과 문제 해결 역량을 갖추고 있습니다. 여러 해커톤과 오픈소스 프로젝트에 참여하며 실무 감각을 익혔고, 컨퍼런스를 통해 업계 트렌드를 학습하며 네트워킹을 적극적으로 활용해왔습니다. 앞으로 데이터 분석과 AI 기술을 활용하여 가치 있는 서비스를 개발하고, 변화하는 환경 속에서 끊임없이 성장하는 개발자가 되고 싶습니다. 이번 기회를 통해 실무 경험을 쌓으며, IT 업계에서 더욱 발전할 수 있도록 최선을 다하겠습니다.',
+    tech_stacks = 'Java, AWS, Spring Boot, MySQL, Docker, JPA, github-actions, SonarQube, Redis, junit5, Mockito, Git',
+    age_group = 'AGE_20_24',
+    education_level = 2,
+    experience_level = 1
 WHERE attendee_id = 1;
 
 UPDATE attendee
 SET
-is_hiring_interested = 1,
-tech_stacks = 'AWS',
-age_group = 'AGE_20_24',
-education_level = 2,
-experience_level = 2,
-current_job_position_id = 12,
-current_job_group_id = 2,
-desired_job_group_id = 2,
-self_introduction = '최신 사람입니다!'
+    is_hiring_interested = 1,
+    tech_stacks = 'AWS',
+    age_group = 'AGE_20_24',
+    education_level = 2,
+    experience_level = 2,
+    current_job_position_id = 12,
+    current_job_group_id = 2,
+    desired_job_group_id = 2,
+    desired_job_position_id = 12,
+    self_introduction = '최신 사람입니다!'
 WHERE attendee_id = 2;
 
 UPDATE attendee
 SET
-is_hiring_interested = 1,
-tech_stacks = 'Ruby',
-age_group = 'AGE_25_29',
-education_level = 1,
-experience_level = 1,
-current_job_position_id = 11,
-current_job_group_id = 2,
-desired_job_group_id = 2,
-self_introduction = '사람입니다!'
+    is_hiring_interested = 1,
+    tech_stacks = 'Ruby',
+    age_group = 'AGE_25_29',
+    education_level = 1,
+    experience_level = 1,
+    current_job_position_id = 11,
+    current_job_group_id = 2,
+    desired_job_group_id = 2,
+    desired_job_position_id = 10,
+    self_introduction = '사람입니다!'
 WHERE attendee_id = 3;
 
 UPDATE attendee
 SET
-is_hiring_interested = 1,
-tech_stacks = 'Go, C++',
-age_group = 'AGE_35_PLUS',
-education_level = 3,
-experience_level = 3,
-current_job_position_id = 1,
-current_job_group_id = 1,
-desired_job_group_id = 1,
-self_introduction = '혼자서 할 수 있는 개발자!'
+    is_hiring_interested = 1,
+    tech_stacks = 'Go, C++',
+    age_group = 'AGE_35_PLUS',
+    education_level = 3,
+    experience_level = 3,
+    current_job_position_id = 1,
+    current_job_group_id = 1,
+    desired_job_group_id = 1,
+    desired_job_position_id = 2,
+    self_introduction = '혼자서 할 수 있는 개발자!'
 WHERE attendee_id = 4;
 
 UPDATE attendee
 SET
-is_hiring_interested = 1,
-tech_stacks = 'Go, C++',
-age_group = 'AGE_35_PLUS',
-education_level = 3,
-experience_level = 3,
-current_job_position_id = 1,
-current_job_group_id = 1,
-desired_job_group_id = 1,
-self_introduction = '혼자서 할 수 있는 개발자!'
+    is_hiring_interested = 1,
+    tech_stacks = 'Go, C++',
+    age_group = 'AGE_35_PLUS',
+    education_level = 3,
+    experience_level = 3,
+    current_job_position_id = 1,
+    current_job_group_id = 1,
+    desired_job_group_id = 1,
+    desired_job_position_id = 2,
+    self_introduction = '혼자서 할 수 있는 개발자!'
 WHERE attendee_id = 5;
 
 UPDATE attendee
 SET
-is_hiring_interested = 1,
-tech_stacks = 'Git, Docker',
-age_group = 'AGE_30_34',
-education_level = 3,
-experience_level = 3,
-current_job_position_id = 1,
-current_job_group_id = 1,
-desired_job_group_id = 1,
-self_introduction = '100인 분 할 수 있는 개발자!'
+    is_hiring_interested = 1,
+    tech_stacks = 'Git, Docker',
+    age_group = 'AGE_30_34',
+    education_level = 3,
+    experience_level = 3,
+    current_job_position_id = 1,
+    current_job_group_id = 1,
+    desired_job_group_id = 1,
+    desired_job_position_id = 2,
+    self_introduction = '100인 분 할 수 있는 개발자!'
 WHERE attendee_id = 6;
 
 -- 참가자의 관심 분야(Interest) 매핑

--- a/src/test/java/com/synergy/backend/domain/member/api/RecruiterControllerTest.java
+++ b/src/test/java/com/synergy/backend/domain/member/api/RecruiterControllerTest.java
@@ -4,13 +4,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.synergy.backend.domain.member.api.dto.AttendeeFilterRequest;
 import com.synergy.backend.domain.member.api.dto.AttendeeListResponse;
-import com.synergy.backend.domain.member.api.dto.AttendeeSimpleResponseDto;
+//import com.synergy.backend.domain.member.api.dto.AttendeeSimpleResponseDto;
+import com.synergy.backend.domain.member.api.dto.resposne.AttendeeSimpleResponseDto;
 import com.synergy.backend.domain.member.entity.RoleType;
 import com.synergy.backend.domain.member.entity.details.ExperienceLevelType;
 import com.synergy.backend.domain.member.service.RecruiterAttendeeLikeService;
 import com.synergy.backend.domain.member.service.RecruiterService;
+import com.synergy.backend.global.jwt.JwtProvider;
 import com.synergy.backend.global.security.CustomUserDetailsService;
-import com.synergy.backend.global.security.JwtProvider;
+//import com.synergy.backend.global.security.JwtProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,29 +75,29 @@ class RecruiterControllerTest {
 
         // 전부다 수도권, 부산광역시 / 4년제 졸업, 20~24세 이하 라는 가정
         List<AttendeeSimpleResponseDto> attendeesCandidates = List.of(
-                new AttendeeSimpleResponseDto("김지원1", null, "백엔드 개발자", JUNIOR, "Java, Spring", false),
-                new AttendeeSimpleResponseDto("김지원2", null, "백엔드 개발자", JUNIOR, "Java, Spring", true),
-                new AttendeeSimpleResponseDto("김지원3", null, "백엔드 개발자", MID_LEVEL, "Java, Spring", true),
-                new AttendeeSimpleResponseDto("김지원4", null, "백엔드 개발자", MID_LEVEL, "Java, Spring", true),
-                new AttendeeSimpleResponseDto("김지원5", null, "백엔드 개발자", JUNIOR, "Java, Spring", true),
-                new AttendeeSimpleResponseDto("김지원6", null, "프론트엔드 개발자", JUNIOR, "React", true),
-                new AttendeeSimpleResponseDto("김지원7", null, "프론트엔드 개발자", JUNIOR, "React", true),
-                new AttendeeSimpleResponseDto("김지원8", null, "프론트엔드 개발자", JUNIOR, "React", true),
-                new AttendeeSimpleResponseDto("김지원9", null, "프론트엔드 개발자", MID_LEVEL, "React", true),
-                new AttendeeSimpleResponseDto("김지원10", null, "풀스택 개발자", JUNIOR, "All", true),
-                new AttendeeSimpleResponseDto("김지원11", null, "풀스택 개발자", JUNIOR, "All", true),
-                new AttendeeSimpleResponseDto("정서연12", null, "UI/UX 디자이너", MID_LEVEL, "Figma", true),
-                new AttendeeSimpleResponseDto("정서연13", null, "UI/UX 디자이너", JUNIOR, "Figma", true)
+                new AttendeeSimpleResponseDto(1L, "김지원1", null, "백엔드 개발자", JUNIOR, "Java, Spring", false),
+                new AttendeeSimpleResponseDto(2L,"김지원2", null, "백엔드 개발자", JUNIOR, "Java, Spring", true),
+                new AttendeeSimpleResponseDto(3L,"김지원3", null, "백엔드 개발자", MID_LEVEL, "Java, Spring", true),
+                new AttendeeSimpleResponseDto(3L,"김지원4", null, "백엔드 개발자", MID_LEVEL, "Java, Spring", true),
+                new AttendeeSimpleResponseDto(4L,"김지원5", null, "백엔드 개발자", JUNIOR, "Java, Spring", true),
+                new AttendeeSimpleResponseDto(5L,"김지원6", null, "프론트엔드 개발자", JUNIOR, "React", true),
+                new AttendeeSimpleResponseDto(6L,"김지원7", null, "프론트엔드 개발자", JUNIOR, "React", true),
+                new AttendeeSimpleResponseDto(7L,"김지원8", null, "프론트엔드 개발자", JUNIOR, "React", true),
+                new AttendeeSimpleResponseDto(8L,"김지원9", null, "프론트엔드 개발자", MID_LEVEL, "React", true),
+                new AttendeeSimpleResponseDto(9L,"김지원10", null, "풀스택 개발자", JUNIOR, "All", true),
+                new AttendeeSimpleResponseDto(10L,"김지원11", null, "풀스택 개발자", JUNIOR, "All", true),
+                new AttendeeSimpleResponseDto(11L,"정서연12", null, "UI/UX 디자이너", MID_LEVEL, "Figma", true),
+                new AttendeeSimpleResponseDto(12L,"정서연13", null, "UI/UX 디자이너", JUNIOR, "Figma", true)
         );
 
 
         List<AttendeeSimpleResponseDto> attendees = List.of(
-                new AttendeeSimpleResponseDto("김지원1", null, "백엔드 개발자", JUNIOR, "Java, Spring", false),
-                new AttendeeSimpleResponseDto("김지원2", null, "백엔드 개발자", JUNIOR, "Java, Spring", true),
-                new AttendeeSimpleResponseDto("김지원5", null, "백엔드 개발자", JUNIOR, "Java, Spring", true),
-                new AttendeeSimpleResponseDto("김지원6", null, "프론트엔드 개발자", JUNIOR, "React", true),
-                new AttendeeSimpleResponseDto("김지원7", null, "프론트엔드 개발자", JUNIOR, "React", true),
-                new AttendeeSimpleResponseDto("김지원8", null, "프론트엔드 개발자", JUNIOR, "React", true)
+                new AttendeeSimpleResponseDto(1L,"김지원1", null, "백엔드 개발자", JUNIOR, "Java, Spring", false),
+                new AttendeeSimpleResponseDto(2L,"김지원2", null, "백엔드 개발자", JUNIOR, "Java, Spring", true),
+                new AttendeeSimpleResponseDto(5L,"김지원5", null, "백엔드 개발자", JUNIOR, "Java, Spring", true),
+                new AttendeeSimpleResponseDto(6L,"김지원6", null, "프론트엔드 개발자", JUNIOR, "React", true),
+                new AttendeeSimpleResponseDto(7L,"김지원7", null, "프론트엔드 개발자", JUNIOR, "React", true),
+                new AttendeeSimpleResponseDto(8L,"김지원8", null, "프론트엔드 개발자", JUNIOR, "React", true)
         );
 
         Page<AttendeeSimpleResponseDto> page = new PageImpl<>(attendees, PageRequest.of(0, 10), attendees.size());
@@ -104,7 +106,7 @@ class RecruiterControllerTest {
         given(recruiterService.getAttendeesBy(any(Pageable.class), eq(recruiterId), eq(requestCondition)))
                 .willReturn(response);
         given(jwtProvider.validateToken(anyString())).willReturn(true);
-        given(jwtProvider.getEmailOrAuthCodeFromToken(anyString())).willReturn("RC12345");
+        //given(jwtProvider.getEmailOrAuthCodeFromToken(anyString())).willReturn("RC12345");
         given(jwtProvider.getRoleTypeFromToken(anyString())).willReturn(RoleType.RECRUITER);
         given(userDetailsService.loadUserByUsername(anyString())).willReturn(mock(UserDetails.class));
 
@@ -124,22 +126,22 @@ class RecruiterControllerTest {
                 .andExpect(jsonPath("$.data.currentPageNumber").value(0))
                 .andExpect(jsonPath("$.data.totalElements").value(6))
                 .andExpect(jsonPath("$.data.list[0].name").value("김지원1"))
-                .andExpect(jsonPath("$.data.list[0].occupation").value("백엔드 개발자"))
+                .andExpect(jsonPath("$.data.list[0].desiredJobPosition").value("백엔드 개발자"))
                 .andExpect(jsonPath("$.data.list[0].experienceLevel").value(JUNIOR.getDescription()))
                 .andExpect(jsonPath("$.data.list[1].name").value("김지원2"))
-                .andExpect(jsonPath("$.data.list[1].occupation").value("백엔드 개발자"))
+                .andExpect(jsonPath("$.data.list[1].desiredJobPosition").value("백엔드 개발자"))
                 .andExpect(jsonPath("$.data.list[1].experienceLevel").value(JUNIOR.getDescription()))
                 .andExpect(jsonPath("$.data.list[2].name").value("김지원5"))
-                .andExpect(jsonPath("$.data.list[2].occupation").value("백엔드 개발자"))
+                .andExpect(jsonPath("$.data.list[2].desiredJobPosition").value("백엔드 개발자"))
                 .andExpect(jsonPath("$.data.list[2].experienceLevel").value(JUNIOR.getDescription()))
                 .andExpect(jsonPath("$.data.list[3].name").value("김지원6"))
-                .andExpect(jsonPath("$.data.list[3].occupation").value("프론트엔드 개발자"))
+                .andExpect(jsonPath("$.data.list[3].desiredJobPosition").value("프론트엔드 개발자"))
                 .andExpect(jsonPath("$.data.list[3].experienceLevel").value(JUNIOR.getDescription()))
                 .andExpect(jsonPath("$.data.list[4].name").value("김지원7"))
-                .andExpect(jsonPath("$.data.list[4].occupation").value("프론트엔드 개발자"))
+                .andExpect(jsonPath("$.data.list[4].desiredJobPosition").value("프론트엔드 개발자"))
                 .andExpect(jsonPath("$.data.list[4].experienceLevel").value(JUNIOR.getDescription()))
                 .andExpect(jsonPath("$.data.list[5].name").value("김지원8"))
-                .andExpect(jsonPath("$.data.list[5].occupation").value("프론트엔드 개발자"))
+                .andExpect(jsonPath("$.data.list[5].desiredJobPosition").value("프론트엔드 개발자"))
                 .andExpect(jsonPath("$.data.list[5].experienceLevel").value(JUNIOR.getDescription()))
                 .andDo(print());
 

--- a/src/test/java/com/synergy/backend/domain/member/api/RecruiterControllerTest.java
+++ b/src/test/java/com/synergy/backend/domain/member/api/RecruiterControllerTest.java
@@ -1,0 +1,150 @@
+package com.synergy.backend.domain.member.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.synergy.backend.domain.member.api.dto.AttendeeFilterRequest;
+import com.synergy.backend.domain.member.api.dto.AttendeeListResponse;
+import com.synergy.backend.domain.member.api.dto.AttendeeSimpleResponseDto;
+import com.synergy.backend.domain.member.entity.RoleType;
+import com.synergy.backend.domain.member.entity.details.ExperienceLevelType;
+import com.synergy.backend.domain.member.service.RecruiterAttendeeLikeService;
+import com.synergy.backend.domain.member.service.RecruiterService;
+import com.synergy.backend.global.security.CustomUserDetailsService;
+import com.synergy.backend.global.security.JwtProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static com.synergy.backend.domain.member.entity.details.ExperienceLevelType.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = RecruiterController.class)
+class RecruiterControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @MockitoBean
+    RecruiterService recruiterService;
+    @MockitoBean
+    JwtProvider jwtProvider;
+    @MockitoBean
+    CustomUserDetailsService userDetailsService;
+    @MockitoBean
+    RecruiterAttendeeLikeService recruiterAttendeeLikeService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+
+    @DisplayName("채용담당자가 참가자 목록을 조회합니다.")
+    @Test
+    @WithMockUser(username = "RC12345", roles = {"RECRUITER"})
+    void getAttendees() throws Exception {
+        // given
+        Long recruiterId = 1L;
+        List<String> occupations = List.of("백엔드", "프론트엔드");
+        String educationLevel = "4년제 졸업";
+        String ageGroup = "20~24세 이하";
+        String experienceLevel = "1~2년 이하";
+        List<String> desiredRegions = List.of("수도권", "부산광역시");
+
+        AttendeeFilterRequest requestCondition = AttendeeFilterRequest.of(
+                occupations, educationLevel, ageGroup, experienceLevel, desiredRegions
+        );
+
+        // 전부다 수도권, 부산광역시 / 4년제 졸업, 20~24세 이하 라는 가정
+        List<AttendeeSimpleResponseDto> attendeesCandidates = List.of(
+                new AttendeeSimpleResponseDto("김지원1", null, "백엔드 개발자", JUNIOR, "Java, Spring", false),
+                new AttendeeSimpleResponseDto("김지원2", null, "백엔드 개발자", JUNIOR, "Java, Spring", true),
+                new AttendeeSimpleResponseDto("김지원3", null, "백엔드 개발자", MID_LEVEL, "Java, Spring", true),
+                new AttendeeSimpleResponseDto("김지원4", null, "백엔드 개발자", MID_LEVEL, "Java, Spring", true),
+                new AttendeeSimpleResponseDto("김지원5", null, "백엔드 개발자", JUNIOR, "Java, Spring", true),
+                new AttendeeSimpleResponseDto("김지원6", null, "프론트엔드 개발자", JUNIOR, "React", true),
+                new AttendeeSimpleResponseDto("김지원7", null, "프론트엔드 개발자", JUNIOR, "React", true),
+                new AttendeeSimpleResponseDto("김지원8", null, "프론트엔드 개발자", JUNIOR, "React", true),
+                new AttendeeSimpleResponseDto("김지원9", null, "프론트엔드 개발자", MID_LEVEL, "React", true),
+                new AttendeeSimpleResponseDto("김지원10", null, "풀스택 개발자", JUNIOR, "All", true),
+                new AttendeeSimpleResponseDto("김지원11", null, "풀스택 개발자", JUNIOR, "All", true),
+                new AttendeeSimpleResponseDto("정서연12", null, "UI/UX 디자이너", MID_LEVEL, "Figma", true),
+                new AttendeeSimpleResponseDto("정서연13", null, "UI/UX 디자이너", JUNIOR, "Figma", true)
+        );
+
+
+        List<AttendeeSimpleResponseDto> attendees = List.of(
+                new AttendeeSimpleResponseDto("김지원1", null, "백엔드 개발자", JUNIOR, "Java, Spring", false),
+                new AttendeeSimpleResponseDto("김지원2", null, "백엔드 개발자", JUNIOR, "Java, Spring", true),
+                new AttendeeSimpleResponseDto("김지원5", null, "백엔드 개발자", JUNIOR, "Java, Spring", true),
+                new AttendeeSimpleResponseDto("김지원6", null, "프론트엔드 개발자", JUNIOR, "React", true),
+                new AttendeeSimpleResponseDto("김지원7", null, "프론트엔드 개발자", JUNIOR, "React", true),
+                new AttendeeSimpleResponseDto("김지원8", null, "프론트엔드 개발자", JUNIOR, "React", true)
+        );
+
+        Page<AttendeeSimpleResponseDto> page = new PageImpl<>(attendees, PageRequest.of(0, 10), attendees.size());
+        AttendeeListResponse response = AttendeeListResponse.from(page);
+
+        given(recruiterService.getAttendeesBy(any(Pageable.class), eq(recruiterId), eq(requestCondition)))
+                .willReturn(response);
+        given(jwtProvider.validateToken(anyString())).willReturn(true);
+        given(jwtProvider.getEmailOrAuthCodeFromToken(anyString())).willReturn("RC12345");
+        given(jwtProvider.getRoleTypeFromToken(anyString())).willReturn(RoleType.RECRUITER);
+        given(userDetailsService.loadUserByUsername(anyString())).willReturn(mock(UserDetails.class));
+
+
+        // when & then
+        mockMvc.perform(get("/api/v1/recruiter/{id}/attendees", recruiterId)
+                        .with(csrf())
+                        .param("occupations", occupations.get(0), occupations.get(1))
+                        .param("educationLevel", educationLevel)
+                        .param("ageGroup", ageGroup)
+                        .param("experienceLevel", experienceLevel)
+                        .param("regions", desiredRegions.get(0), desiredRegions.get(1))
+                        .param("page", "0")
+                        .param("size", "20")
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.currentPageNumber").value(0))
+                .andExpect(jsonPath("$.data.totalElements").value(6))
+                .andExpect(jsonPath("$.data.list[0].name").value("김지원1"))
+                .andExpect(jsonPath("$.data.list[0].occupation").value("백엔드 개발자"))
+                .andExpect(jsonPath("$.data.list[0].experienceLevel").value(JUNIOR.getDescription()))
+                .andExpect(jsonPath("$.data.list[1].name").value("김지원2"))
+                .andExpect(jsonPath("$.data.list[1].occupation").value("백엔드 개발자"))
+                .andExpect(jsonPath("$.data.list[1].experienceLevel").value(JUNIOR.getDescription()))
+                .andExpect(jsonPath("$.data.list[2].name").value("김지원5"))
+                .andExpect(jsonPath("$.data.list[2].occupation").value("백엔드 개발자"))
+                .andExpect(jsonPath("$.data.list[2].experienceLevel").value(JUNIOR.getDescription()))
+                .andExpect(jsonPath("$.data.list[3].name").value("김지원6"))
+                .andExpect(jsonPath("$.data.list[3].occupation").value("프론트엔드 개발자"))
+                .andExpect(jsonPath("$.data.list[3].experienceLevel").value(JUNIOR.getDescription()))
+                .andExpect(jsonPath("$.data.list[4].name").value("김지원7"))
+                .andExpect(jsonPath("$.data.list[4].occupation").value("프론트엔드 개발자"))
+                .andExpect(jsonPath("$.data.list[4].experienceLevel").value(JUNIOR.getDescription()))
+                .andExpect(jsonPath("$.data.list[5].name").value("김지원8"))
+                .andExpect(jsonPath("$.data.list[5].occupation").value("프론트엔드 개발자"))
+                .andExpect(jsonPath("$.data.list[5].experienceLevel").value(JUNIOR.getDescription()))
+                .andDo(print());
+
+
+    }
+
+
+}

--- a/src/test/java/com/synergy/backend/domain/member/repository/spring/AttendeeRepositoryTest.java
+++ b/src/test/java/com/synergy/backend/domain/member/repository/spring/AttendeeRepositoryTest.java
@@ -1,13 +1,11 @@
 package com.synergy.backend.domain.member.repository.spring;
 
 import com.synergy.backend.domain.member.api.dto.AttendeeFilterRequest;
-import com.synergy.backend.domain.member.api.dto.AttendeeSimpleResponseDto;
-import com.synergy.backend.domain.member.entity.Attendee;
+import com.synergy.backend.domain.member.api.dto.resposne.AttendeeSimpleResponseDto;
 import com.synergy.backend.domain.member.entity.Recruiter;
 import com.synergy.backend.domain.member.repository.AttendeeRepository;
 import com.synergy.backend.domain.member.repository.RecruiterRepository;
 import com.synergy.backend.global.config.QuerydslConfig;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +18,8 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 @DataJpaTest
 @ActiveProfiles("test")
@@ -46,7 +45,6 @@ class AttendeeRepositoryTest {
         String experienceLevel = null;
         List<String> regions = List.of();
         AttendeeFilterRequest requestCondition = AttendeeFilterRequest.of(occupations, educationLevel, ageGroup, experienceLevel, regions);
-
         // when
         Page<AttendeeSimpleResponseDto> result = attendeeRepository.searchPageAttendeesBy(pageable, savedRecruiter.getId(), requestCondition);
 
@@ -58,12 +56,12 @@ class AttendeeRepositoryTest {
 
         List<AttendeeSimpleResponseDto> content = result.getContent();
         assertThat(content)
-                .extracting("name", "occupation", "experienceLevel", "techStacks")
+                .extracting("name", "desiredJobPosition", "experienceLevel", "techStacks")
                 .containsExactlyInAnyOrder(
                         tuple("김지원", "백엔드 개발자", "1~2년 이하", "Java, AWS, Spring Boot, MySQL, Docker, JPA, github-actions, SonarQube, Redis, junit5, Mockito, Git"),
-                        tuple("박시형", "프론트엔드 개발자", "신입", "Go, C++"),
-                        tuple("이다영", "프론트엔드 개발자", "신입", "Go, C++"),
-                        tuple("김다혜", "프론트엔드 개발자", "신입", "Git, Docker")
+                        tuple("박시형", "백엔드 개발자", "신입", "Go, C++"),
+                        tuple("이다영", "백엔드 개발자", "신입", "Go, C++"),
+                        tuple("김다혜", "백엔드 개발자", "신입", "Git, Docker")
                 );
 
 

--- a/src/test/java/com/synergy/backend/domain/member/repository/spring/AttendeeRepositoryTest.java
+++ b/src/test/java/com/synergy/backend/domain/member/repository/spring/AttendeeRepositoryTest.java
@@ -1,0 +1,72 @@
+package com.synergy.backend.domain.member.repository.spring;
+
+import com.synergy.backend.domain.member.api.dto.AttendeeFilterRequest;
+import com.synergy.backend.domain.member.api.dto.AttendeeSimpleResponseDto;
+import com.synergy.backend.domain.member.entity.Attendee;
+import com.synergy.backend.domain.member.entity.Recruiter;
+import com.synergy.backend.domain.member.repository.AttendeeRepository;
+import com.synergy.backend.domain.member.repository.RecruiterRepository;
+import com.synergy.backend.global.config.QuerydslConfig;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(QuerydslConfig.class)
+class AttendeeRepositoryTest {
+
+    @Autowired
+    AttendeeRepository attendeeRepository;
+
+    @Autowired
+    RecruiterRepository recruiterRepository;
+
+    @DisplayName("각종 필터를 기준으로 페이징 조회를 반환합니다.")
+    @Test
+    void searchPageAttendeesBy() {
+        // given
+        Recruiter savedRecruiter = recruiterRepository.save(Recruiter.of("RC_TEST"));
+        Pageable pageable = PageRequest.of(0, 10);
+
+        List<String> occupations = List.of("백엔드 개발자", "프론트엔드 개발자");
+        String educationLevel = null;
+        String ageGroup = null;
+        String experienceLevel = null;
+        List<String> regions = List.of();
+        AttendeeFilterRequest requestCondition = AttendeeFilterRequest.of(occupations, educationLevel, ageGroup, experienceLevel, regions);
+
+        // when
+        Page<AttendeeSimpleResponseDto> result = attendeeRepository.searchPageAttendeesBy(pageable, savedRecruiter.getId(), requestCondition);
+
+
+        // then
+        assertThat(result.getNumber()).isEqualTo(0);
+        assertThat(result.getTotalPages()).isEqualTo(1);
+        assertThat(result.getTotalElements()).isEqualTo(4L);
+
+        List<AttendeeSimpleResponseDto> content = result.getContent();
+        assertThat(content)
+                .extracting("name", "occupation", "experienceLevel", "techStacks")
+                .containsExactlyInAnyOrder(
+                        tuple("김지원", "백엔드 개발자", "1~2년 이하", "Java, AWS, Spring Boot, MySQL, Docker, JPA, github-actions, SonarQube, Redis, junit5, Mockito, Git"),
+                        tuple("박시형", "프론트엔드 개발자", "신입", "Go, C++"),
+                        tuple("이다영", "프론트엔드 개발자", "신입", "Go, C++"),
+                        tuple("김다혜", "프론트엔드 개발자", "신입", "Git, Docker")
+                );
+
+
+    }
+
+}

--- a/src/test/java/com/synergy/backend/domain/member/service/RecruiterServiceImplTest.java
+++ b/src/test/java/com/synergy/backend/domain/member/service/RecruiterServiceImplTest.java
@@ -1,121 +1,117 @@
 package com.synergy.backend.domain.member.service;
 
-import static com.synergy.backend.domain.member.entity.details.ExperienceLevelType.*;
-import static org.assertj.core.api.Assertions.tuple;
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.*;
-
-import java.util.List;
-import java.util.Optional;
-
 import com.synergy.backend.domain.member.api.dto.AttendeeFilterRequest;
 import com.synergy.backend.domain.member.api.dto.AttendeeListResponse;
-import com.synergy.backend.domain.member.api.dto.AttendeeSimpleResponseDto;
-import com.synergy.backend.domain.member.entity.details.ExperienceLevelType;
+import com.synergy.backend.domain.member.api.dto.resposne.AttendeeSimpleResponseDto;
+import com.synergy.backend.domain.member.api.dto.resposne.RecruiterMyInfoResponseDto;
+import com.synergy.backend.domain.member.entity.Recruiter;
+import com.synergy.backend.domain.member.exception.NotFoundRecruiterException;
 import com.synergy.backend.domain.member.repository.AttendeeRepository;
-import org.assertj.core.api.Assertions;
+import com.synergy.backend.domain.member.repository.RecruiterRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import com.synergy.backend.domain.member.api.dto.resposne.RecruiterMyInfoResponseDto;
-import com.synergy.backend.domain.member.entity.Recruiter;
-import com.synergy.backend.domain.member.exception.NotFoundRecruiterException;
-import com.synergy.backend.domain.member.repository.RecruiterRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+import java.util.Optional;
+
+import static com.synergy.backend.domain.member.entity.details.ExperienceLevelType.JUNIOR;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.*;
+
 @ExtendWith(MockitoExtension.class)
 class RecruiterServiceImplTest {
 
-	@Mock
-	private RecruiterRepository recruiterRepository;
-	@Mock
-	private AttendeeRepository attendeeRepository;
+    @Mock
+    private RecruiterRepository recruiterRepository;
+    @Mock
+    private AttendeeRepository attendeeRepository;
 
-	@InjectMocks
-	private RecruiterServiceImpl recruiterService;
+    @InjectMocks
+    private RecruiterServiceImpl recruiterService;
 
-	private Recruiter recruiter;
+    private Recruiter recruiter;
 
-	@BeforeEach
-	void setUp() {
-		recruiter = Recruiter.of("RC12345");
-	}
+    @BeforeEach
+    void setUp() {
+        recruiter = Recruiter.of("RC12345");
+    }
 
-	@DisplayName("채용담당자가 본인의 프로필을 조회한다.")
-	@Test
-	void testGetMyInformation_Success() {
-		// given
-		Long recruiterId = 1L;
-		when(recruiterRepository.findById(recruiterId)).thenReturn(Optional.of(recruiter));
+    @DisplayName("채용담당자가 본인의 프로필을 조회한다.")
+    @Test
+    void testGetMyInformation_Success() {
+        // given
+        Long recruiterId = 1L;
+        when(recruiterRepository.findById(recruiterId)).thenReturn(Optional.of(recruiter));
 
-		// when
-		RecruiterMyInfoResponseDto response = recruiterService.getMyInformation(recruiterId);
+        // when
+        RecruiterMyInfoResponseDto response = recruiterService.getMyInformation(recruiterId);
 
-		// then
-		assertEquals(RecruiterMyInfoResponseDto.from(recruiter), response);
-	}
+        // then
+        assertEquals(RecruiterMyInfoResponseDto.from(recruiter), response);
+    }
 
-	@DisplayName("존재하지 않는 아이디의 채용담당자 조회 시도 시 예외가 발생한다.")
-	@Test
-	void testGetMyInformation_NotFound() {
-		// given
-		Long recruiterId = 1L;
-		when(recruiterRepository.findById(recruiterId)).thenReturn(Optional.empty());
+    @DisplayName("존재하지 않는 아이디의 채용담당자 조회 시도 시 예외가 발생한다.")
+    @Test
+    void testGetMyInformation_NotFound() {
+        // given
+        Long recruiterId = 1L;
+        when(recruiterRepository.findById(recruiterId)).thenReturn(Optional.empty());
 
-		//when & then
-		assertThrows(NotFoundRecruiterException.class, () -> recruiterService.getMyInformation(recruiterId));
-	}
+        //when & then
+        assertThrows(NotFoundRecruiterException.class, () -> recruiterService.getMyInformation(recruiterId));
+    }
 
 
-	@Test
-	@DisplayName("필터 조건에 맞는 참가자 리스트를 페이징하여 반환한다.")
-	void testGetAttendeesBy() {
-		// given
-		Long recruiterId = 1L;
-		Pageable pageable = PageRequest.of(0, 5);
-		AttendeeFilterRequest requestCondition = AttendeeFilterRequest.of(
-				List.of("백엔드", "프론트엔드"),
-				"4년제 졸업",
-				"20~24세 이하",
-				"1~2년 이하",
-				List.of("서울", "부산")
-		);
-		List<AttendeeSimpleResponseDto> mockAttendees = List.of(
-				new AttendeeSimpleResponseDto("김지원", null, "백엔드 개발자", JUNIOR, "Java, Spring", true),
-				new AttendeeSimpleResponseDto("정서연", null, "프론트엔드 개발자", JUNIOR, "React", false)
-		);
+    @Test
+    @DisplayName("필터 조건에 맞는 참가자 리스트를 페이징하여 반환한다.")
+    void testGetAttendeesBy() {
+        // given
+        Long recruiterId = 1L;
+        Pageable pageable = PageRequest.of(0, 5);
+        AttendeeFilterRequest requestCondition = AttendeeFilterRequest.of(
+                List.of("백엔드", "프론트엔드"),
+                "4년제 졸업",
+                "20~24세 이하",
+                "1~2년 이하",
+                List.of("서울", "부산")
+        );
+        List<AttendeeSimpleResponseDto> mockAttendees = List.of(
+                new AttendeeSimpleResponseDto(1L, "김지원", null, "백엔드 개발자", JUNIOR, "Java, Spring", true),
+                new AttendeeSimpleResponseDto(2L, "정서연", null, "프론트엔드 개발자", JUNIOR, "React", false)
+        );
 
-		Page<AttendeeSimpleResponseDto> mockPage = new PageImpl<>(mockAttendees, pageable, mockAttendees.size());
-		given(attendeeRepository.searchPageAttendeesBy(eq(pageable), eq(recruiterId), eq(requestCondition)))
-				.willReturn(mockPage);
+        Page<AttendeeSimpleResponseDto> mockPage = new PageImpl<>(mockAttendees, pageable, mockAttendees.size());
+        given(attendeeRepository.searchPageAttendeesBy(eq(pageable), eq(recruiterId), eq(requestCondition)))
+                .willReturn(mockPage);
 
-		// when
-		AttendeeListResponse result = recruiterService.getAttendeesBy(pageable, recruiterId, requestCondition);
+        // when
+        AttendeeListResponse result = recruiterService.getAttendeesBy(pageable, recruiterId, requestCondition);
 
-		// then
-		assertThat(result).isNotNull();
-		assertThat(result)
-				.extracting("currentPageNumber", "totalPages", "totalElements", "pageSize")
-						.containsExactly(0, 1, 2L, 5);
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result)
+                .extracting("currentPageNumber", "totalPages", "totalElements", "pageSize")
+                .containsExactly(0, 1, 2L, 5);
 
-		assertThat(result.getList())
-				.hasSize(2)
-				.extracting("name", "occupation", "experienceLevel", "liked")
-				.containsExactlyInAnyOrder(
-						tuple("김지원", "백엔드 개발자", JUNIOR.getDescription(), true),
-						tuple("정서연", "프론트엔드 개발자", JUNIOR.getDescription(), false)
-				);
-	}
+        assertThat(result.getList())
+                .hasSize(2)
+                .extracting("name", "desiredJobPosition", "experienceLevel", "liked")
+                .containsExactlyInAnyOrder(
+                        tuple("김지원", "백엔드 개발자", JUNIOR.getDescription(), true),
+                        tuple("정서연", "프론트엔드 개발자", JUNIOR.getDescription(), false)
+                );
+    }
 
 }

--- a/src/test/java/com/synergy/backend/domain/member/service/RecruiterServiceImplTest.java
+++ b/src/test/java/com/synergy/backend/domain/member/service/RecruiterServiceImplTest.java
@@ -1,14 +1,26 @@
 package com.synergy.backend.domain.member.service;
 
+import static com.synergy.backend.domain.member.entity.details.ExperienceLevelType.*;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.*;
 
+import java.util.List;
 import java.util.Optional;
 
+import com.synergy.backend.domain.member.api.dto.AttendeeFilterRequest;
+import com.synergy.backend.domain.member.api.dto.AttendeeListResponse;
+import com.synergy.backend.domain.member.api.dto.AttendeeSimpleResponseDto;
+import com.synergy.backend.domain.member.entity.details.ExperienceLevelType;
+import com.synergy.backend.domain.member.repository.AttendeeRepository;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,12 +29,18 @@ import com.synergy.backend.domain.member.api.dto.resposne.RecruiterMyInfoRespons
 import com.synergy.backend.domain.member.entity.Recruiter;
 import com.synergy.backend.domain.member.exception.NotFoundRecruiterException;
 import com.synergy.backend.domain.member.repository.RecruiterRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 class RecruiterServiceImplTest {
 
 	@Mock
 	private RecruiterRepository recruiterRepository;
+	@Mock
+	private AttendeeRepository attendeeRepository;
 
 	@InjectMocks
 	private RecruiterServiceImpl recruiterService;
@@ -58,4 +76,46 @@ class RecruiterServiceImplTest {
 		//when & then
 		assertThrows(NotFoundRecruiterException.class, () -> recruiterService.getMyInformation(recruiterId));
 	}
+
+
+	@Test
+	@DisplayName("필터 조건에 맞는 참가자 리스트를 페이징하여 반환한다.")
+	void testGetAttendeesBy() {
+		// given
+		Long recruiterId = 1L;
+		Pageable pageable = PageRequest.of(0, 5);
+		AttendeeFilterRequest requestCondition = AttendeeFilterRequest.of(
+				List.of("백엔드", "프론트엔드"),
+				"4년제 졸업",
+				"20~24세 이하",
+				"1~2년 이하",
+				List.of("서울", "부산")
+		);
+		List<AttendeeSimpleResponseDto> mockAttendees = List.of(
+				new AttendeeSimpleResponseDto("김지원", null, "백엔드 개발자", JUNIOR, "Java, Spring", true),
+				new AttendeeSimpleResponseDto("정서연", null, "프론트엔드 개발자", JUNIOR, "React", false)
+		);
+
+		Page<AttendeeSimpleResponseDto> mockPage = new PageImpl<>(mockAttendees, pageable, mockAttendees.size());
+		given(attendeeRepository.searchPageAttendeesBy(eq(pageable), eq(recruiterId), eq(requestCondition)))
+				.willReturn(mockPage);
+
+		// when
+		AttendeeListResponse result = recruiterService.getAttendeesBy(pageable, recruiterId, requestCondition);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result)
+				.extracting("currentPageNumber", "totalPages", "totalElements", "pageSize")
+						.containsExactly(0, 1, 2L, 5);
+
+		assertThat(result.getList())
+				.hasSize(2)
+				.extracting("name", "occupation", "experienceLevel", "liked")
+				.containsExactlyInAnyOrder(
+						tuple("김지원", "백엔드 개발자", JUNIOR.getDescription(), true),
+						tuple("정서연", "프론트엔드 개발자", JUNIOR.getDescription(), false)
+				);
+	}
+
 }

--- a/src/test/java/com/synergy/backend/domain/member/service/spring/RecruiterServiceImplTest.java
+++ b/src/test/java/com/synergy/backend/domain/member/service/spring/RecruiterServiceImplTest.java
@@ -1,0 +1,72 @@
+package com.synergy.backend.domain.member.service.spring;
+
+import com.synergy.backend.domain.member.api.dto.AttendeeFilterRequest;
+import com.synergy.backend.domain.member.api.dto.AttendeeListResponse;
+import com.synergy.backend.domain.member.entity.Attendee;
+import com.synergy.backend.domain.member.entity.Recruiter;
+import com.synergy.backend.domain.member.repository.AttendeeRepository;
+import com.synergy.backend.domain.member.repository.RecruiterRepository;
+import com.synergy.backend.domain.member.service.RecruiterService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class RecruiterServiceImplTest {
+
+    @Autowired
+    RecruiterService recruiterService;
+    @Autowired
+    RecruiterRepository recruiterRepository;
+
+    @DisplayName("필터 조건에 맞는 참가자 리스트를 페이징하여 반환한다.")
+    @Test
+    void getAttendeesBy() {
+        // given
+        Recruiter recruiter = Recruiter.of("AUTH_TEST");
+        Recruiter savedRecruiter = recruiterRepository.save(recruiter);
+        /**
+         * data-test.sql 로 테스트 진행
+         * 개인적으로는 sql 파일과 이동하면서 매칭해야 하기에 보기 어려운 거 같습니다.
+         *
+         */
+
+        Pageable pageable = PageRequest.of(0, 10);
+        List<String> occupations = List.of("백엔드 개발자", "그래픽 디자이너");
+        String educationLevel = null;
+        String ageGroup = "20~24세 이하";
+        String experienceLevel = "1~2년 이하";
+        List<String> regions = List.of();
+        AttendeeFilterRequest requestCondition = AttendeeFilterRequest.of(occupations, educationLevel, ageGroup, experienceLevel, regions);
+
+        // when
+        AttendeeListResponse result = recruiterService.getAttendeesBy(pageable, savedRecruiter.getId(), requestCondition);
+
+        // then
+        assertThat(result)
+                .extracting("currentPageNumber", "totalPages", "totalElements", "pageSize")
+                .containsExactly(pageable.getPageNumber(), 1, 1L, pageable.getPageSize());
+
+        assertThat(result.getList())
+                .hasSize(1)
+                .extracting("name", "occupation", "experienceLevel")
+                .containsExactlyInAnyOrder(
+                        tuple("김지원", "백엔드 개발자", "1~2년 이하")
+                );
+
+    }
+
+
+}

--- a/src/test/java/com/synergy/backend/domain/member/service/spring/RecruiterServiceImplTest.java
+++ b/src/test/java/com/synergy/backend/domain/member/service/spring/RecruiterServiceImplTest.java
@@ -2,7 +2,6 @@ package com.synergy.backend.domain.member.service.spring;
 
 import com.synergy.backend.domain.member.api.dto.AttendeeFilterRequest;
 import com.synergy.backend.domain.member.api.dto.AttendeeListResponse;
-import com.synergy.backend.domain.member.entity.Attendee;
 import com.synergy.backend.domain.member.entity.Recruiter;
 import com.synergy.backend.domain.member.repository.AttendeeRepository;
 import com.synergy.backend.domain.member.repository.RecruiterRepository;
@@ -30,6 +29,8 @@ class RecruiterServiceImplTest {
     RecruiterService recruiterService;
     @Autowired
     RecruiterRepository recruiterRepository;
+    @Autowired
+    private AttendeeRepository attendeeRepository;
 
     @DisplayName("필터 조건에 맞는 참가자 리스트를 페이징하여 반환한다.")
     @Test
@@ -44,12 +45,13 @@ class RecruiterServiceImplTest {
          */
 
         Pageable pageable = PageRequest.of(0, 10);
-        List<String> occupations = List.of("백엔드 개발자", "그래픽 디자이너");
+        List<String> desiredOccupations = List.of("백엔드 개발자", "그래픽 디자이너");
         String educationLevel = null;
         String ageGroup = "20~24세 이하";
         String experienceLevel = "1~2년 이하";
         List<String> regions = List.of();
-        AttendeeFilterRequest requestCondition = AttendeeFilterRequest.of(occupations, educationLevel, ageGroup, experienceLevel, regions);
+        AttendeeFilterRequest requestCondition = AttendeeFilterRequest.of(desiredOccupations, educationLevel, ageGroup, experienceLevel, regions);
+
 
         // when
         AttendeeListResponse result = recruiterService.getAttendeesBy(pageable, savedRecruiter.getId(), requestCondition);
@@ -61,7 +63,7 @@ class RecruiterServiceImplTest {
 
         assertThat(result.getList())
                 .hasSize(1)
-                .extracting("name", "occupation", "experienceLevel")
+                .extracting("name", "desiredJobPosition", "experienceLevel")
                 .containsExactlyInAnyOrder(
                         tuple("김지원", "백엔드 개발자", "1~2년 이하")
                 );


### PR DESCRIPTION
## 개요
채용 담당자 사용자 목록 조회 기능에 대한 3계층 테스트 코드를 작성했습니다.
추가로 사용자 목록 조회에서 잘못된 비즈니스 로직 이해가 있어 수정했습니다.

[수정 내용]
현재 직무 -> 희망 직무
현재 직무가 아닌 희망 직무에 대한 필터 조건과 반환하는 값도 희망 직무이기에 이에 맞게 수정했습니다.

## 진행한 이슈
- close #102 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 진행 사항
<img width="592" alt="image" src="https://github.com/user-attachments/assets/38f40e0f-70f2-4c99-a997-750c566d3603" />
<img width="811" alt="image" src="https://github.com/user-attachments/assets/38305321-1e7e-4ac7-abdc-4c7ec6d41a43" />

로컬 상에서도 data.sql 기반으로 정상적으로 반영되는 부분 확인했습니다.

