### PR TITLE
feat: 로그인 재시도 제한, test code

### DIFF
--- a/src/docs/plantuml/auth/LoginAttemptAccountLock.puml
+++ b/src/docs/plantuml/auth/LoginAttemptAccountLock.puml
@@ -1,0 +1,69 @@
+@startuml
+title 로그인 시도 초과 → 계정 잠김 → 인증 → 잠금 해제 시나리오
+
+actor 사용자
+participant "AuthController" as Controller
+participant "AuthService" as AuthService
+participant "LoginFailedRepository\n(Redis)" as Redis
+participant "AttendeeRepository\n(DB)" as DB
+participant "AccountLockService" as LockService
+participant "ApplicationEventPublisher" as EventPublisher
+participant "AccountLockedEventListener" as Listener
+participant "MailService" as MailService
+
+== 로그인 실패 처리 ==
+
+사용자 -> Controller : 로그인 요청 (잘못된 비밀번호)
+Controller -> AuthService : 로그인 처리
+
+AuthService -> Redis : 로그인 실패 횟수 증가
+Redis --> AuthService : 실패 횟수 반환 (예: 5회)
+
+alt 실패 횟수 ≥ 제한 횟수
+    AuthService -> LockService : 계정 잠금 처리
+    LockService -> DB : 사용자 조회
+    DB --> LockService : 사용자 정보 반환
+
+    LockService -> DB : 계정 isLocked = true 로 변경
+    LockService -> DB : 계정 저장
+
+    LockService -> EventPublisher : AccountLockedEvent 발행
+    EventPublisher -> Listener : 이벤트 수신
+    Listener -> MailService : 인증 메일 전송 (잠금 해제용)
+end
+
+AuthService --> Controller : 로그인 실패 응답 (계정 잠김 안내 포함)
+
+== 로그인 시도 (잠긴 상태) ==
+
+사용자 -> Controller : 로그인 시도
+Controller -> AuthService : 로그인 처리
+AuthService -> DB : 사용자 조회
+DB --> AuthService : 잠긴 사용자 정보
+AuthService --> Controller : 로그인 실패 응답 (계정 잠김 상태)
+
+== 이메일 인증 및 잠금 해제 ==
+
+사용자 -> Controller : 이메일 인증 코드 입력
+Controller -> MailService : 인증 코드 검증
+MailService --> Controller : 인증 성공 여부 반환
+
+alt 인증 성공 & 용도: UNLOCK_ACCOUNT
+    Controller -> AuthService : 계정 잠금 해제 요청
+    AuthService -> DB : 사용자 조회
+    DB --> AuthService : 사용자 정보 반환
+    AuthService -> DB : isLocked = false 저장
+    AuthService -> Redis : 실패 기록 삭제
+end
+
+== 로그인 시도 (잠금 해제 후) ==
+
+사용자 -> Controller : 로그인 요청 (정상 정보)
+Controller -> AuthService : 로그인 처리
+AuthService -> DB : 사용자 조회
+AuthService -> Redis : 실패 기록 조회
+Redis --> AuthService : 실패 기록 없음
+
+AuthService --> Controller : 로그인 성공 응답
+
+@enduml

--- a/src/main/java/com/synergy/backend/domain/auth/AccountLockedEvent.java
+++ b/src/main/java/com/synergy/backend/domain/auth/AccountLockedEvent.java
@@ -1,0 +1,3 @@
+package com.synergy.backend.domain.auth;
+
+public record AccountLockedEvent(String email) {}

--- a/src/main/java/com/synergy/backend/domain/auth/AccountLockedEventHandler.java
+++ b/src/main/java/com/synergy/backend/domain/auth/AccountLockedEventHandler.java
@@ -1,0 +1,20 @@
+package com.synergy.backend.domain.auth;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import com.synergy.backend.global.mail.MailService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AccountLockedEventHandler {
+
+	private final MailService mailService;
+
+	@EventListener
+	public void handleAccountLocked(AccountLockedEvent event) {
+		mailService.sendVerificationCodeToMail(event.email());
+	}
+}

--- a/src/main/java/com/synergy/backend/domain/auth/LoginFailedRepository.java
+++ b/src/main/java/com/synergy/backend/domain/auth/LoginFailedRepository.java
@@ -48,4 +48,5 @@ public class LoginFailedRepository {
 	public void delete(String email) {
 		redisTemplate.delete(getKey(email));
 	}
+
 }

--- a/src/main/java/com/synergy/backend/domain/auth/LoginFailedRepository.java
+++ b/src/main/java/com/synergy/backend/domain/auth/LoginFailedRepository.java
@@ -1,0 +1,43 @@
+package com.synergy.backend.domain.auth;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class LoginFailedRepository {
+
+	private static final long LOCK_TTL_MINUTES = 30;
+	private static final String PREFIX_FOR_KEY = "ULF: ";
+
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	public void setValue(String username, Integer failedCount) {
+		String key = getKey(username);
+		redisTemplate.opsForValue().set(key, failedCount, Duration.ofMillis(LOCK_TTL_MINUTES));
+		log.info("[LoginFailedRepository]count login failed for user : {}", username);
+	}
+
+	public Integer getValues(String username) {
+
+		return (Integer)redisTemplate.opsForValue().get(getKey(username));
+	}
+
+	private String getKey(String username) {
+		return PREFIX_FOR_KEY + username;
+	}
+
+	public Long increment(String username) {
+		return redisTemplate.opsForValue().increment(getKey(username));
+	}
+
+	public void delete(String username) {
+		redisTemplate.delete(getKey(username));
+	}
+}

--- a/src/main/java/com/synergy/backend/domain/auth/LoginFailedRepository.java
+++ b/src/main/java/com/synergy/backend/domain/auth/LoginFailedRepository.java
@@ -41,8 +41,9 @@ public class LoginFailedRepository {
 		return PREFIX_FOR_KEY + email;
 	}
 
-	public Long increment(String email) {
-		return redisTemplate.opsForValue().increment(getKey(email));
+	public Integer increment(String email) {
+		Long result = redisTemplate.opsForValue().increment(getKey(email));
+		return result != null ? result.intValue() : 0;
 	}
 
 	public void delete(String email) {

--- a/src/main/java/com/synergy/backend/domain/auth/LoginFailedRepository.java
+++ b/src/main/java/com/synergy/backend/domain/auth/LoginFailedRepository.java
@@ -49,4 +49,8 @@ public class LoginFailedRepository {
 		redisTemplate.delete(getKey(email));
 	}
 
+	public boolean exists(String email) {
+		String key = getKey(email);
+		return redisTemplate.hasKey(key);
+	}
 }

--- a/src/main/java/com/synergy/backend/domain/auth/LoginFailedRepository.java
+++ b/src/main/java/com/synergy/backend/domain/auth/LoginFailedRepository.java
@@ -13,31 +13,39 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class LoginFailedRepository {
 
+	public static final Integer INIT_LOGIN_TRIAL_COUNT = 0;
+	public static final Integer MAX_ATTEMPT_COUNT = 5;
 	private static final long LOCK_TTL_MINUTES = 30;
-	private static final String PREFIX_FOR_KEY = "ULF: ";
+	private static final String PREFIX_FOR_KEY = "ULF:";
 
 	private final RedisTemplate<String, Object> redisTemplate;
 
-	public void setValue(String username, Integer failedCount) {
-		String key = getKey(username);
+	public void setValue(String email, Integer failedCount) {
+		String key = getKey(email);
 		redisTemplate.opsForValue().set(key, failedCount, Duration.ofMillis(LOCK_TTL_MINUTES));
-		log.info("[LoginFailedRepository]count login failed for user : {}", username);
+		log.info("[LoginFailedRepository]count login failed for user : {}", email);
 	}
 
-	public Integer getValues(String username) {
-
-		return (Integer)redisTemplate.opsForValue().get(getKey(username));
+	public Integer getValues(String email) {
+		Object value = redisTemplate.opsForValue().get(getKey(email));
+		if (value instanceof Long) {
+			return ((Long)value).intValue();
+		} else if (value instanceof Integer) {
+			return (Integer)value;
+		} else {
+			return 0;
+		}
 	}
 
-	private String getKey(String username) {
-		return PREFIX_FOR_KEY + username;
+	private String getKey(String email) {
+		return PREFIX_FOR_KEY + email;
 	}
 
-	public Long increment(String username) {
-		return redisTemplate.opsForValue().increment(getKey(username));
+	public Long increment(String email) {
+		return redisTemplate.opsForValue().increment(getKey(email));
 	}
 
-	public void delete(String username) {
-		redisTemplate.delete(getKey(username));
+	public void delete(String email) {
+		redisTemplate.delete(getKey(email));
 	}
 }

--- a/src/main/java/com/synergy/backend/domain/booth/controller/BoothController.java
+++ b/src/main/java/com/synergy/backend/domain/booth/controller/BoothController.java
@@ -38,7 +38,7 @@ public class BoothController {
             @PathVariable Long id
     ) {
 
-        return ApiResponse.ok(boothService.getBoothById(conferenceId, id), 200);
+        return ApiResponse.ok(boothService.getBoothById(user.getIdentifier(), user.getRole(), conferenceId, id), 200);
     }
 
 	@SwaggerSummaryRole({RoleType.ADMIN, RoleType.RECRUITER, RoleType.ATTENDEE})@PreAuthorize("hasAnyRole('ADMIN', 'ATTENDEE', 'RECRUITER')")
@@ -56,7 +56,7 @@ public class BoothController {
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "부스 생성", description = "해당 컨퍼런스에 새로운 부스를 생성합니다.")
     @PostMapping
-    public ApiResponse<BoothDetailResponseDto> createBooth(
+    public ApiResponse createBooth(
             @AuthenticationPrincipal CustomUserDetails user,
             @RequestHeader(value = "Origin") String router,
             @PathVariable Long conferenceId,
@@ -64,7 +64,9 @@ public class BoothController {
             @RequestPart MultipartFile imageFile
     ) throws WriterException {
 
-        return ApiResponse.ok(boothService.createBooth(conferenceId, router, requestDto, imageFile), 201);
+        boothService.createBooth(conferenceId, router, requestDto, imageFile);
+
+        return ApiResponse.ok("Booth created Successfully!", 201);
     }
 
 	@SwaggerSummaryRole({RoleType.ADMIN})

--- a/src/main/java/com/synergy/backend/domain/booth/controller/BoothDashboardController.java
+++ b/src/main/java/com/synergy/backend/domain/booth/controller/BoothDashboardController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.synergy.backend.domain.booth.dto.BoothParticipationResponseDto;
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationResponseDto;
 import com.synergy.backend.domain.booth.service.BoothParticipationService;
 import com.synergy.backend.domain.member.entity.RoleType;
 import com.synergy.backend.global.annotation.SwaggerSummaryRole;

--- a/src/main/java/com/synergy/backend/domain/booth/controller/BoothDashboardController.java
+++ b/src/main/java/com/synergy/backend/domain/booth/controller/BoothDashboardController.java
@@ -6,6 +6,7 @@ import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipate
 import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationInterestedResponseDto;
 import com.synergy.backend.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,6 +29,7 @@ public class BoothDashboardController {
 	private final BoothParticipationService boothParticipationService;
 
 	@SwaggerSummaryRole({RoleType.ADMIN})
+	@PreAuthorize("hasRole('ADMIN')")
 	@GetMapping("/booths/participation")
 	public ApiResponse<BoothParticipateRateResDto> getBoothParticipateRate(
 			@AuthenticationPrincipal CustomUserDetails currentUser,
@@ -37,6 +39,7 @@ public class BoothDashboardController {
 	}
 
 	@SwaggerSummaryRole({RoleType.ADMIN})
+	@PreAuthorize("hasRole('ADMIN')")
 	@GetMapping("/booths/participation/interest")
 	public ApiResponse<List<BoothParticipationInterestedResponseDto>> getParticipationCountByInterest(
 		@PathVariable Long conferenceId) {

--- a/src/main/java/com/synergy/backend/domain/booth/controller/BoothDashboardController.java
+++ b/src/main/java/com/synergy/backend/domain/booth/controller/BoothDashboardController.java
@@ -2,8 +2,11 @@ package com.synergy.backend.domain.booth.controller;
 
 import java.util.List;
 
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipateRateResDto;
 import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationInterestedResponseDto;
+import com.synergy.backend.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,6 +26,15 @@ import lombok.RequiredArgsConstructor;
 public class BoothDashboardController {
 
 	private final BoothParticipationService boothParticipationService;
+
+	@SwaggerSummaryRole({RoleType.ADMIN})
+	@GetMapping("/booths/participation")
+	public ApiResponse<BoothParticipateRateResDto> getBoothParticipateRate(
+			@AuthenticationPrincipal CustomUserDetails currentUser,
+			@PathVariable Long conferenceId) {
+
+		return ApiResponse.ok(boothParticipationService.boothParticipateRate(currentUser.getIdentifier(), conferenceId), 200);
+	}
 
 	@SwaggerSummaryRole({RoleType.ADMIN})
 	@GetMapping("/booths/participation/interest")

--- a/src/main/java/com/synergy/backend/domain/booth/controller/BoothDashboardController.java
+++ b/src/main/java/com/synergy/backend/domain/booth/controller/BoothDashboardController.java
@@ -2,13 +2,13 @@ package com.synergy.backend.domain.booth.controller;
 
 import java.util.List;
 
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationInterestedResponseDto;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationResponseDto;
 import com.synergy.backend.domain.booth.service.BoothParticipationService;
 import com.synergy.backend.domain.member.entity.RoleType;
 import com.synergy.backend.global.annotation.SwaggerSummaryRole;
@@ -26,9 +26,9 @@ public class BoothDashboardController {
 
 	@SwaggerSummaryRole({RoleType.ADMIN})
 	@GetMapping("/booths/participation/interest")
-	public ApiResponse<List<BoothParticipationResponseDto>> getParticipationCountByInterest(
+	public ApiResponse<List<BoothParticipationInterestedResponseDto>> getParticipationCountByInterest(
 		@PathVariable Long conferenceId) {
-		List<BoothParticipationResponseDto> result = boothParticipationService.getParticipationCountByInterest(conferenceId);
+		List<BoothParticipationInterestedResponseDto> result = boothParticipationService.getParticipationCountByInterest(conferenceId);
 		return ApiResponse.ok(result, 200);
 	}
 }

--- a/src/main/java/com/synergy/backend/domain/booth/controller/BoothVerifyController.java
+++ b/src/main/java/com/synergy/backend/domain/booth/controller/BoothVerifyController.java
@@ -1,12 +1,17 @@
 package com.synergy.backend.domain.booth.controller;
 
+import com.synergy.backend.domain.booth.dto.BoothResponseDto;
 import com.synergy.backend.domain.booth.service.BoothParticipationService;
 import com.synergy.backend.domain.member.entity.RoleType;
+import com.synergy.backend.domain.session.dto.sessionDto.SessionResDto;
 import com.synergy.backend.global.annotation.SwaggerSummaryRole;
 import com.synergy.backend.global.common.ApiResponse;
+import com.synergy.backend.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Booth Verify Controller", description = "부스 참여자 관련 API")
@@ -19,14 +24,17 @@ public class BoothVerifyController {
 
     @Operation(
             summary = "부스 참여",
-            description = "부스 ID를 기준으로 해당 부스에 참여합니다."
+            description = "QR 코드를 활용해 부스에 참여합니다. 부스 ID와 QR 코드로 유효성을 검증합니다."
     )
     @SwaggerSummaryRole({RoleType.ATTENDEE})
-    @PostMapping("/{boothId}/participate/{attendeeId}")
-    public ApiResponse<String> participateInBooth(
+    @PreAuthorize("hasAnyRole('ATTENDEE')")
+    @PostMapping("/booth/{boothId}")
+    public ApiResponse<BoothResponseDto> participateInBooth(
+            @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable(name = "boothId") Long boothId,
-            @PathVariable(name = "attendeeId") Long attendeeId) {
-        boothParticipationService.participateInBooth(attendeeId, boothId);
-        return ApiResponse.ok("부스 참여가 완료되었습니다.", 201);
+            @RequestParam(name = "qrCode") String qrCode) {
+
+        return ApiResponse.ok(boothParticipationService.participateInBooth(user.getIdentifier(), boothId, qrCode), 201);
     }
+
 }

--- a/src/main/java/com/synergy/backend/domain/booth/dto/BoothDetailResponseDto.java
+++ b/src/main/java/com/synergy/backend/domain/booth/dto/BoothDetailResponseDto.java
@@ -15,9 +15,10 @@ public record BoothDetailResponseDto(
         LocalDate progressDate,
         String boothDescription,
         String qrUrl,
-        String imageUrl
+        String imageUrl,
+        Boolean isQRVerify
 ) {
-    public BoothDetailResponseDto(Booth booth) {
+    public BoothDetailResponseDto(Booth booth, Boolean isQRVerify) {
         this(
                 booth.getId(),
                 booth.getCompanyName(),
@@ -27,7 +28,8 @@ public record BoothDetailResponseDto(
                 booth.getProgressDate(),
                 booth.getBoothDescription(),
                 booth.getQrUrl(),
-                booth.getImageUrl()
+                booth.getImageUrl(),
+                isQRVerify
         );
     }
 }

--- a/src/main/java/com/synergy/backend/domain/booth/dto/BoothDetailResponseDto.java
+++ b/src/main/java/com/synergy/backend/domain/booth/dto/BoothDetailResponseDto.java
@@ -14,7 +14,6 @@ public record BoothDetailResponseDto(
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
         LocalDate progressDate,
         String boothDescription,
-        String qrUrl,
         String imageUrl,
         Boolean isQRVerify
 ) {
@@ -27,7 +26,6 @@ public record BoothDetailResponseDto(
                 booth.getBoothNumber(),
                 booth.getProgressDate(),
                 booth.getBoothDescription(),
-                booth.getQrUrl(),
                 booth.getImageUrl(),
                 isQRVerify
         );

--- a/src/main/java/com/synergy/backend/domain/booth/dto/BoothResponseDto.java
+++ b/src/main/java/com/synergy/backend/domain/booth/dto/BoothResponseDto.java
@@ -11,7 +11,7 @@ public record BoothResponseDto(
         String image
 ) {
 
-    public static BoothResponseDto of(Booth booth) {
+    public static BoothResponseDto from(Booth booth) {
         return new BoothResponseDto(
                 booth.getId(),
                 booth.getCompanyName(),

--- a/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/BoothParticipateDetailDto.java
+++ b/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/BoothParticipateDetailDto.java
@@ -1,0 +1,8 @@
+package com.synergy.backend.domain.booth.dto.boothParticipateDto;
+
+public record BoothParticipateDetailDto(
+        Long boothId,
+        Long rank,
+        String companyName
+) {
+}

--- a/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/BoothParticipateDetailDto.java
+++ b/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/BoothParticipateDetailDto.java
@@ -2,7 +2,7 @@ package com.synergy.backend.domain.booth.dto.boothParticipateDto;
 
 public record BoothParticipateDetailDto(
         Long boothId,
-        Long rank,
+        String attendeePercent,
         String companyName
 ) {
 }

--- a/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/BoothParticipateInterestedTechDto.java
+++ b/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/BoothParticipateInterestedTechDto.java
@@ -6,13 +6,13 @@ import lombok.Getter;
 @Getter
 public class BoothParticipateInterestedTechDto {
     private Long boothId;
-    private String interestedTech;
-    private long count;
+    private String tech;
+    private long attendeeCount;
 
     @QueryProjection
     public BoothParticipateInterestedTechDto(Long boothId, long count, String interestedTech) {
         this.boothId = boothId;
-        this.count = count;
-        this.interestedTech = interestedTech;
+        this.attendeeCount = count;
+        this.tech = interestedTech;
     }
 }

--- a/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/BoothParticipateInterestedTechDto.java
+++ b/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/BoothParticipateInterestedTechDto.java
@@ -1,4 +1,4 @@
-package com.synergy.backend.domain.booth.dto;
+package com.synergy.backend.domain.booth.dto.boothParticipateDto;
 
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;

--- a/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/BoothParticipateRateResDto.java
+++ b/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/BoothParticipateRateResDto.java
@@ -1,0 +1,10 @@
+package com.synergy.backend.domain.booth.dto.boothParticipateDto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record BoothParticipateRateResDto(
+        LocalDate currentDate,
+        List<BoothParticipateDetailDto> boothParticipateDetailDtoList
+) {
+}

--- a/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/BoothParticipationInterestedResponseDto.java
+++ b/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/BoothParticipationInterestedResponseDto.java
@@ -17,7 +17,7 @@ public class BoothParticipationInterestedResponseDto {
 	private String boothNumber;
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM/dd")
 	private LocalDate progressDate;
-	private List<BoothParticipateInterestedTechDto> techs;
+	private List<BoothParticipateInterestedTechDto> dataset;
 
 	@QueryProjection
 	public BoothParticipationInterestedResponseDto(Long boothId, String companyName, String companyType, String boothLocation,
@@ -28,10 +28,10 @@ public class BoothParticipationInterestedResponseDto {
 		this.boothLocation = boothLocation;
 		this.boothNumber = boothNumber;
 		this.progressDate = progressDate;
-		this.techs = new ArrayList<>();
+		this.dataset = new ArrayList<>();
 	}
 
 	public void addTechs(List<BoothParticipateInterestedTechDto> techs) {
-		this.techs = techs;
+		this.dataset = techs;
 	}
 }

--- a/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/BoothParticipationInterestedResponseDto.java
+++ b/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/BoothParticipationInterestedResponseDto.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-public class BoothParticipationResponseDto {
+public class BoothParticipationInterestedResponseDto {
 	private Long boothId;
 	private String companyName;
 	private String companyType;
@@ -20,8 +20,8 @@ public class BoothParticipationResponseDto {
 	private List<BoothParticipateInterestedTechDto> techs;
 
 	@QueryProjection
-	public BoothParticipationResponseDto(Long boothId, String companyName, String companyType, String boothLocation,
-										 String boothNumber, LocalDate progressDate) {
+	public BoothParticipationInterestedResponseDto(Long boothId, String companyName, String companyType, String boothLocation,
+												   String boothNumber, LocalDate progressDate) {
 		this.boothId = boothId;
 		this.companyName = companyName;
 		this.companyType = companyType;

--- a/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/BoothParticipationResponseDto.java
+++ b/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/BoothParticipationResponseDto.java
@@ -1,4 +1,4 @@
-package com.synergy.backend.domain.booth.dto;
+package com.synergy.backend.domain.booth.dto.boothParticipateDto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.querydsl.core.annotations.QueryProjection;

--- a/src/main/java/com/synergy/backend/domain/booth/repository/BoothParticipationRepository.java
+++ b/src/main/java/com/synergy/backend/domain/booth/repository/BoothParticipationRepository.java
@@ -1,6 +1,7 @@
 package com.synergy.backend.domain.booth.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -17,7 +18,7 @@ public interface BoothParticipationRepository extends JpaRepository<BoothPartici
 
 	List<BoothParticipation> findByBooth(Booth booth);
 
-	boolean existsByBoothIdAndAttendeeId(Long boothId, Long attendeeId);
+	Optional<BoothParticipation> existsByBoothIdAndAttendeeId(Long boothId, Long attendeeId);
 
 	@Modifying(clearAutomatically = true, flushAutomatically = true)
 	@Query("DELETE FROM BoothParticipation bp WHERE bp.booth = :booth")

--- a/src/main/java/com/synergy/backend/domain/booth/repository/BoothParticipationRepository.java
+++ b/src/main/java/com/synergy/backend/domain/booth/repository/BoothParticipationRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import com.synergy.backend.domain.booth.dto.BoothParticipationResponseDto;
 import com.synergy.backend.domain.booth.entity.Booth;
 import com.synergy.backend.domain.booth.entity.BoothParticipation;
 
@@ -24,7 +23,7 @@ public interface BoothParticipationRepository extends JpaRepository<BoothPartici
 	@Query("DELETE FROM BoothParticipation bp WHERE bp.booth = :booth")
 	void deleteByBooth(@Param("booth") Booth booth);
 
-	/*@Query("SELECT new com.synergy.backend.domain.booth.dto.BoothParticipationResponseDto(i.name, COUNT(bp)) " +
+	/*@Query("SELECT new com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationResponseDto(i.name, COUNT(bp)) " +
 		"FROM BoothParticipation bp " +
 		"JOIN bp.attendee a " +
 		"JOIN a.attendeeInterests ai " +

--- a/src/main/java/com/synergy/backend/domain/booth/repository/BoothRepository.java
+++ b/src/main/java/com/synergy/backend/domain/booth/repository/BoothRepository.java
@@ -10,5 +10,8 @@ import java.util.Optional;
 
 public interface BoothRepository extends JpaRepository<Booth, Long>, BoothRepositoryCustom {
     Optional<Booth> findByIdAndConferenceId(Long id, Long conferenceId);
+
     Page<Booth> findAllByConferenceId(Long conferenceId, Pageable pageable);
+
+    Optional<Booth> findByIdAndSecretCode(Long boothId, String secretCode);
 }

--- a/src/main/java/com/synergy/backend/domain/booth/repository/querydsl/BoothRepositoryCustom.java
+++ b/src/main/java/com/synergy/backend/domain/booth/repository/querydsl/BoothRepositoryCustom.java
@@ -1,6 +1,6 @@
 package com.synergy.backend.domain.booth.repository.querydsl;
 
-import com.synergy.backend.domain.booth.dto.BoothParticipationResponseDto;
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationResponseDto;
 
 import java.util.List;
 

--- a/src/main/java/com/synergy/backend/domain/booth/repository/querydsl/BoothRepositoryCustom.java
+++ b/src/main/java/com/synergy/backend/domain/booth/repository/querydsl/BoothRepositoryCustom.java
@@ -1,12 +1,14 @@
 package com.synergy.backend.domain.booth.repository.querydsl;
 
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipateRateResDto;
 import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationInterestedResponseDto;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface BoothRepositoryCustom {
 
-    BoothPar
+    BoothParticipateRateResDto searchBoothRank(Long conferenceId, LocalDate currentDate);
 
     List<BoothParticipationInterestedResponseDto> searchBoothParticipation(Long conferenceId);
 }

--- a/src/main/java/com/synergy/backend/domain/booth/repository/querydsl/BoothRepositoryCustom.java
+++ b/src/main/java/com/synergy/backend/domain/booth/repository/querydsl/BoothRepositoryCustom.java
@@ -1,10 +1,12 @@
 package com.synergy.backend.domain.booth.repository.querydsl;
 
-import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationResponseDto;
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationInterestedResponseDto;
 
 import java.util.List;
 
 public interface BoothRepositoryCustom {
 
-    List<BoothParticipationResponseDto> searchBoothParticipation(Long conferenceId);
+    BoothPar
+
+    List<BoothParticipationInterestedResponseDto> searchBoothParticipation(Long conferenceId);
 }

--- a/src/main/java/com/synergy/backend/domain/booth/repository/querydsl/BoothRepositoryImpl.java
+++ b/src/main/java/com/synergy/backend/domain/booth/repository/querydsl/BoothRepositoryImpl.java
@@ -3,7 +3,7 @@ package com.synergy.backend.domain.booth.repository.querydsl;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipateInterestedTechDto;
-import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationResponseDto;
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationInterestedResponseDto;
 import com.synergy.backend.domain.booth.dto.QBoothParticipateInterestedTechDto;
 import com.synergy.backend.domain.booth.dto.QBoothParticipationResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -25,8 +25,8 @@ public class BoothRepositoryImpl implements BoothRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<BoothParticipationResponseDto> searchBoothParticipation(Long conferenceId) {
-        List<BoothParticipationResponseDto> booths = queryFactory
+    public List<BoothParticipationInterestedResponseDto> searchBoothParticipation(Long conferenceId) {
+        List<BoothParticipationInterestedResponseDto> booths = queryFactory
                 .select(new QBoothParticipationResponseDto(
                         booth.id,
                         booth.companyName,
@@ -62,7 +62,7 @@ public class BoothRepositoryImpl implements BoothRepositoryCustom {
                 .collect(Collectors.groupingBy(BoothParticipateInterestedTechDto::getBoothId));
 
         // 4. 각 부스 DTO에 해당 tech 리스트 주입
-        for (BoothParticipationResponseDto boothDto : booths) {
+        for (BoothParticipationInterestedResponseDto boothDto : booths) {
             boothDto.addTechs(techsByBooth.getOrDefault(boothDto.getBoothId(), List.of()));
         }
 

--- a/src/main/java/com/synergy/backend/domain/booth/repository/querydsl/BoothRepositoryImpl.java
+++ b/src/main/java/com/synergy/backend/domain/booth/repository/querydsl/BoothRepositoryImpl.java
@@ -2,10 +2,12 @@ package com.synergy.backend.domain.booth.repository.querydsl;
 
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.synergy.backend.domain.booth.dto.boothParticipateDto.*;
 import com.synergy.backend.domain.member.repository.AttendeeRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.text.DecimalFormat;
 import java.time.LocalDate;
@@ -20,6 +22,7 @@ import static com.synergy.backend.domain.interest.entity.QAttendeeInterest.atten
 import static com.synergy.backend.domain.interest.entity.QInterest.interest;
 import static com.synergy.backend.domain.member.entity.QAttendee.attendee;
 
+@Slf4j
 @RequiredArgsConstructor
 public class BoothRepositoryImpl implements BoothRepositoryCustom {
 
@@ -30,27 +33,30 @@ public class BoothRepositoryImpl implements BoothRepositoryCustom {
     @Override
     public BoothParticipateRateResDto searchBoothRank(Long conferenceId, LocalDate currentDate) {
         Long attendeeCount = attendeeRepository.count();
+        NumberExpression<Long> countExpression = boothParticipation.count();
 
         List<Tuple> tuples = queryFactory
                 .select(
                         booth.id,
-                        boothParticipation.count().as("percent"),
+                        countExpression,
                         booth.companyName
                 )
                 .from(booth)
-                .leftJoin(boothParticipation).on(booth.id.eq(boothParticipation.id))
+                .leftJoin(boothParticipation).on(booth.id.eq(boothParticipation.booth.id))
                 .where(
-                        booth.conference.id.eq(conferenceId)
+                        booth.conference.id.eq(conferenceId),
+                        booth.progressDate.eq(currentDate)
                 )
                 .groupBy(booth.id)
-                .orderBy(boothParticipation.count().desc())
+                .orderBy(countExpression.desc())
                 .limit(3)
                 .fetch();
 
         List<BoothParticipateDetailDto> list = tuples.stream()
                 .map(tuple -> {
                     Long boothId = tuple.get(booth.id);
-                    Long boothCount = tuple.get(boothParticipation.count());
+                    log.info("totalMember: {}, boothMember: {}" ,attendeeCount, tuple.get(countExpression));
+                    Long boothCount = tuple.get(countExpression);
                     double percent = (double) boothCount / attendeeCount;
                     String attendeePercent = decimalFormat.format(percent * 100) + "%";
                     String companyName = tuple.get(booth.companyName);

--- a/src/main/java/com/synergy/backend/domain/booth/repository/querydsl/BoothRepositoryImpl.java
+++ b/src/main/java/com/synergy/backend/domain/booth/repository/querydsl/BoothRepositoryImpl.java
@@ -2,8 +2,8 @@ package com.synergy.backend.domain.booth.repository.querydsl;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.synergy.backend.domain.booth.dto.BoothParticipateInterestedTechDto;
-import com.synergy.backend.domain.booth.dto.BoothParticipationResponseDto;
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipateInterestedTechDto;
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationResponseDto;
 import com.synergy.backend.domain.booth.dto.QBoothParticipateInterestedTechDto;
 import com.synergy.backend.domain.booth.dto.QBoothParticipationResponseDto;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/synergy/backend/domain/booth/repository/querydsl/BoothRepositoryImpl.java
+++ b/src/main/java/com/synergy/backend/domain/booth/repository/querydsl/BoothRepositoryImpl.java
@@ -1,13 +1,14 @@
 package com.synergy.backend.domain.booth.repository.querydsl;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipateInterestedTechDto;
-import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationInterestedResponseDto;
-import com.synergy.backend.domain.booth.dto.QBoothParticipateInterestedTechDto;
-import com.synergy.backend.domain.booth.dto.QBoothParticipationResponseDto;
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.*;
+import com.synergy.backend.domain.member.repository.AttendeeRepository;
 import lombok.RequiredArgsConstructor;
 
+import java.text.DecimalFormat;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -23,11 +24,47 @@ import static com.synergy.backend.domain.member.entity.QAttendee.attendee;
 public class BoothRepositoryImpl implements BoothRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+    private final AttendeeRepository attendeeRepository;
+    private final DecimalFormat decimalFormat = new DecimalFormat("#.##");
+
+    @Override
+    public BoothParticipateRateResDto searchBoothRank(Long conferenceId, LocalDate currentDate) {
+        Long attendeeCount = attendeeRepository.count();
+
+        List<Tuple> tuples = queryFactory
+                .select(
+                        booth.id,
+                        boothParticipation.count().as("percent"),
+                        booth.companyName
+                )
+                .from(booth)
+                .leftJoin(boothParticipation).on(booth.id.eq(boothParticipation.id))
+                .where(
+                        booth.conference.id.eq(conferenceId)
+                )
+                .groupBy(booth.id)
+                .orderBy(boothParticipation.count().desc())
+                .limit(3)
+                .fetch();
+
+        List<BoothParticipateDetailDto> list = tuples.stream()
+                .map(tuple -> {
+                    Long boothId = tuple.get(booth.id);
+                    Long boothCount = tuple.get(boothParticipation.count());
+                    double percent = (double) boothCount / attendeeCount;
+                    String attendeePercent = decimalFormat.format(percent * 100) + "%";
+                    String companyName = tuple.get(booth.companyName);
+
+                    return new BoothParticipateDetailDto(boothId, attendeePercent, companyName);
+                }).toList();
+
+        return new BoothParticipateRateResDto(currentDate, list);
+    }
 
     @Override
     public List<BoothParticipationInterestedResponseDto> searchBoothParticipation(Long conferenceId) {
         List<BoothParticipationInterestedResponseDto> booths = queryFactory
-                .select(new QBoothParticipationResponseDto(
+                .select(new QBoothParticipationInterestedResponseDto(
                         booth.id,
                         booth.companyName,
                         booth.companyType,

--- a/src/main/java/com/synergy/backend/domain/booth/service/BoothParticipationService.java
+++ b/src/main/java/com/synergy/backend/domain/booth/service/BoothParticipationService.java
@@ -1,12 +1,15 @@
 package com.synergy.backend.domain.booth.service;
 
-import com.synergy.backend.domain.booth.dto.BoothParticipationResponseDto;
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipateRateResDto;
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationResponseDto;
 import com.synergy.backend.domain.booth.dto.BoothResponseDto;
 
 import java.util.List;
 
 public interface BoothParticipationService {
     BoothResponseDto participateInBooth(String identifier, Long boothId, String qrCode);
+
+    BoothParticipateRateResDto boothParticipateRate(String identifier, Long conferenceId);
 
     List<BoothParticipationResponseDto> getParticipationCountByInterest(Long boothId);
 }

--- a/src/main/java/com/synergy/backend/domain/booth/service/BoothParticipationService.java
+++ b/src/main/java/com/synergy/backend/domain/booth/service/BoothParticipationService.java
@@ -1,7 +1,7 @@
 package com.synergy.backend.domain.booth.service;
 
 import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipateRateResDto;
-import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationResponseDto;
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationInterestedResponseDto;
 import com.synergy.backend.domain.booth.dto.BoothResponseDto;
 
 import java.util.List;
@@ -11,5 +11,5 @@ public interface BoothParticipationService {
 
     BoothParticipateRateResDto boothParticipateRate(String identifier, Long conferenceId);
 
-    List<BoothParticipationResponseDto> getParticipationCountByInterest(Long boothId);
+    List<BoothParticipationInterestedResponseDto> getParticipationCountByInterest(Long boothId);
 }

--- a/src/main/java/com/synergy/backend/domain/booth/service/BoothParticipationService.java
+++ b/src/main/java/com/synergy/backend/domain/booth/service/BoothParticipationService.java
@@ -1,11 +1,12 @@
 package com.synergy.backend.domain.booth.service;
 
 import com.synergy.backend.domain.booth.dto.BoothParticipationResponseDto;
+import com.synergy.backend.domain.booth.dto.BoothResponseDto;
 
 import java.util.List;
 
 public interface BoothParticipationService {
-    void participateInBooth(Long attendeeId, Long boothId);
+    BoothResponseDto participateInBooth(String identifier, Long boothId, String qrCode);
 
     List<BoothParticipationResponseDto> getParticipationCountByInterest(Long boothId);
 }

--- a/src/main/java/com/synergy/backend/domain/booth/service/BoothParticipationServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/booth/service/BoothParticipationServiceImpl.java
@@ -1,7 +1,7 @@
 package com.synergy.backend.domain.booth.service;
 
 import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipateRateResDto;
-import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationResponseDto;
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationInterestedResponseDto;
 import com.synergy.backend.domain.booth.dto.BoothResponseDto;
 import com.synergy.backend.domain.booth.entity.Booth;
 import com.synergy.backend.domain.booth.entity.BoothParticipation;
@@ -61,7 +61,7 @@ public class BoothParticipationServiceImpl implements BoothParticipationService 
 
     @Transactional(readOnly = true)
     @Override
-    public List<BoothParticipationResponseDto> getParticipationCountByInterest(Long conferenceId) {
+    public List<BoothParticipationInterestedResponseDto> getParticipationCountByInterest(Long conferenceId) {
         return boothRepository.searchBoothParticipation(conferenceId);
     }
 }

--- a/src/main/java/com/synergy/backend/domain/booth/service/BoothParticipationServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/booth/service/BoothParticipationServiceImpl.java
@@ -1,6 +1,7 @@
 package com.synergy.backend.domain.booth.service;
 
-import com.synergy.backend.domain.booth.dto.BoothParticipationResponseDto;
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipateRateResDto;
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationResponseDto;
 import com.synergy.backend.domain.booth.dto.BoothResponseDto;
 import com.synergy.backend.domain.booth.entity.Booth;
 import com.synergy.backend.domain.booth.entity.BoothParticipation;
@@ -11,14 +12,8 @@ import com.synergy.backend.domain.booth.repository.BoothRepository;
 import com.synergy.backend.domain.member.entity.Attendee;
 import com.synergy.backend.domain.member.exception.NotFoundUserException;
 import com.synergy.backend.domain.member.repository.AttendeeRepository;
-import com.synergy.backend.domain.point.entity.PointType;
 import com.synergy.backend.domain.point.service.PointService;
 import com.synergy.backend.domain.qrCode.service.QrService;
-import com.synergy.backend.domain.session.dto.sessionDto.SessionResDto;
-import com.synergy.backend.domain.session.entity.AttendeeSession;
-import com.synergy.backend.domain.session.entity.Session;
-import com.synergy.backend.domain.session.exception.AlreadyAttendedException;
-import com.synergy.backend.domain.session.exception.NotFoundSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -57,6 +52,11 @@ public class BoothParticipationServiceImpl implements BoothParticipationService 
         pointService.addBoothPoint(attendee.getId(), boothId);
 
         return BoothResponseDto.from(booth);
+    }
+
+    @Override
+    public BoothParticipateRateResDto boothParticipateRate(String identifier, Long conferenceId) {
+        return null;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/synergy/backend/domain/booth/service/BoothParticipationServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/booth/service/BoothParticipationServiceImpl.java
@@ -48,16 +48,16 @@ public class BoothParticipationServiceImpl implements BoothParticipationService 
         Booth booth = boothRepository.findByIdAndSecretCode(boothId, decodingSecretCode)
                 .orElseThrow(NotFoundBoothException::new);
 
-        if (boothParticipationRepository.existsByBoothIdAndAttendeeId(boothId, attendee.getId())) {
-            throw new DuplicateParticipationException();
-        }
+        boothParticipationRepository.existsByBoothIdAndAttendeeId(boothId, attendee.getId())
+                        .ifPresent(boothParticipation -> {
+                                throw new DuplicateParticipationException();
+                        });
 
         boothParticipationRepository.save(BoothParticipation.of(booth, attendee));
         pointService.addBoothPoint(attendee.getId(), boothId);
 
         return BoothResponseDto.from(booth);
     }
-//        return SessionResDto.from(session);
 
     @Transactional(readOnly = true)
     @Override

--- a/src/main/java/com/synergy/backend/domain/booth/service/BoothParticipationServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/booth/service/BoothParticipationServiceImpl.java
@@ -9,8 +9,13 @@ import com.synergy.backend.domain.booth.exception.DuplicateParticipationExceptio
 import com.synergy.backend.domain.booth.exception.NotFoundBoothException;
 import com.synergy.backend.domain.booth.repository.BoothParticipationRepository;
 import com.synergy.backend.domain.booth.repository.BoothRepository;
+import com.synergy.backend.domain.conference.entity.Conference;
+import com.synergy.backend.domain.conference.exception.NotFoundConference;
+import com.synergy.backend.domain.conference.repository.ConferenceRepository;
+import com.synergy.backend.domain.member.entity.Admin;
 import com.synergy.backend.domain.member.entity.Attendee;
 import com.synergy.backend.domain.member.exception.NotFoundUserException;
+import com.synergy.backend.domain.member.repository.AdminRepository;
 import com.synergy.backend.domain.member.repository.AttendeeRepository;
 import com.synergy.backend.domain.point.service.PointService;
 import com.synergy.backend.domain.qrCode.service.QrService;
@@ -19,6 +24,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 
 @Service @Slf4j
@@ -27,7 +34,9 @@ public class BoothParticipationServiceImpl implements BoothParticipationService 
 
     private final BoothParticipationRepository boothParticipationRepository;
     private final BoothRepository boothRepository;
+    private final ConferenceRepository conferenceRepository;
     private final AttendeeRepository attendeeRepository;
+    private final AdminRepository adminRepository;
     private final PointService pointService;
     private final QrService qrService;
 
@@ -56,7 +65,24 @@ public class BoothParticipationServiceImpl implements BoothParticipationService 
 
     @Override
     public BoothParticipateRateResDto boothParticipateRate(String identifier, Long conferenceId) {
-        return null;
+        Admin currentMember = findIfAdminExists(identifier);
+        ifConferenceExists(conferenceId);
+        findIfConferenceMine(currentMember, conferenceId);
+        LocalDate now = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+        return boothRepository.searchBoothRank(conferenceId, now);
+    }
+
+    private void findIfConferenceMine(Admin admin, Long conferenceId) {
+        adminRepository.findByIdAndConferences_Id(admin.getId(), conferenceId);
+    }
+
+    private Conference ifConferenceExists(Long conferenceId) {
+        return conferenceRepository.findById(conferenceId).orElseThrow(NotFoundConference::new);
+    }
+
+    private Admin findIfAdminExists(String identifier) {
+        return adminRepository.findByAdminAuthCode(identifier).orElseThrow(NotFoundUserException::new);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/synergy/backend/domain/booth/service/BoothParticipationServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/booth/service/BoothParticipationServiceImpl.java
@@ -1,6 +1,7 @@
 package com.synergy.backend.domain.booth.service;
 
 import com.synergy.backend.domain.booth.dto.BoothParticipationResponseDto;
+import com.synergy.backend.domain.booth.dto.BoothResponseDto;
 import com.synergy.backend.domain.booth.entity.Booth;
 import com.synergy.backend.domain.booth.entity.BoothParticipation;
 import com.synergy.backend.domain.booth.exception.DuplicateParticipationException;
@@ -12,13 +13,20 @@ import com.synergy.backend.domain.member.exception.NotFoundUserException;
 import com.synergy.backend.domain.member.repository.AttendeeRepository;
 import com.synergy.backend.domain.point.entity.PointType;
 import com.synergy.backend.domain.point.service.PointService;
+import com.synergy.backend.domain.qrCode.service.QrService;
+import com.synergy.backend.domain.session.dto.sessionDto.SessionResDto;
+import com.synergy.backend.domain.session.entity.AttendeeSession;
+import com.synergy.backend.domain.session.entity.Session;
+import com.synergy.backend.domain.session.exception.AlreadyAttendedException;
+import com.synergy.backend.domain.session.exception.NotFoundSession;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-@Service
+@Service @Slf4j
 @RequiredArgsConstructor
 public class BoothParticipationServiceImpl implements BoothParticipationService {
 
@@ -26,24 +34,30 @@ public class BoothParticipationServiceImpl implements BoothParticipationService 
     private final BoothRepository boothRepository;
     private final AttendeeRepository attendeeRepository;
     private final PointService pointService;
+    private final QrService qrService;
 
     @Transactional
     @Override
-    public void participateInBooth(Long attendeeId, Long boothId) {
-        Attendee attendee = attendeeRepository.findById(attendeeId)
+    public BoothResponseDto participateInBooth(String identifier, Long boothId, String secretCode) {
+        Attendee attendee = attendeeRepository.findByEmail(identifier)
                 .orElseThrow(NotFoundUserException::new);
 
-        Booth booth = boothRepository.findById(boothId)
+        String decodingSecretCode = qrService.decodingSecretCode(secretCode);
+        log.info("secretCode = {}", secretCode);
+        log.info("decodingSecretCode = {}", decodingSecretCode);
+        Booth booth = boothRepository.findByIdAndSecretCode(boothId, decodingSecretCode)
                 .orElseThrow(NotFoundBoothException::new);
 
-        if (boothParticipationRepository.existsByBoothIdAndAttendeeId(boothId, attendeeId)) {
+        if (boothParticipationRepository.existsByBoothIdAndAttendeeId(boothId, attendee.getId())) {
             throw new DuplicateParticipationException();
         }
 
         boothParticipationRepository.save(BoothParticipation.of(booth, attendee));
+        pointService.addBoothPoint(attendee.getId(), boothId);
 
-        pointService.addBoothPoint(attendeeId, boothId);
+        return BoothResponseDto.from(booth);
     }
+//        return SessionResDto.from(session);
 
     @Transactional(readOnly = true)
     @Override

--- a/src/main/java/com/synergy/backend/domain/booth/service/BoothService.java
+++ b/src/main/java/com/synergy/backend/domain/booth/service/BoothService.java
@@ -4,14 +4,15 @@ import com.google.zxing.WriterException;
 import com.synergy.backend.domain.booth.dto.BoothRequestDto;
 import com.synergy.backend.domain.booth.dto.BoothDetailResponseDto;
 import com.synergy.backend.domain.booth.dto.BoothResponseDto;
+import com.synergy.backend.domain.member.entity.RoleType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface BoothService {
-    BoothDetailResponseDto getBoothById(Long conferenceId, Long id);
+    BoothDetailResponseDto getBoothById(String identifier, RoleType role, Long conferenceId, Long id);
     Page<BoothResponseDto> getAllBooths(Long conferenceId, Pageable pageable);
-    BoothDetailResponseDto createBooth(Long conferenceId, String router, BoothRequestDto request, MultipartFile imageFile) throws WriterException;
+    void createBooth(Long conferenceId, String router, BoothRequestDto request, MultipartFile imageFile) throws WriterException;
     BoothDetailResponseDto updateBooth(Long conferenceId, Long id, BoothRequestDto request, MultipartFile imageFile);
     void deleteBooth(Long conferenceId, Long id);
 }

--- a/src/main/java/com/synergy/backend/domain/booth/service/BoothServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/booth/service/BoothServiceImpl.java
@@ -43,8 +43,8 @@ public class BoothServiceImpl implements BoothService {
                 request.boothLocation(),
                 request.boothNumber(),
                 request.progressDate(),
-                request.boothDescription(),
                 secretCode,
+                request.boothDescription(),
                 conference
         );
 
@@ -64,7 +64,7 @@ public class BoothServiceImpl implements BoothService {
     @Override
     public Page<BoothResponseDto> getAllBooths(Long conferenceId, Pageable pageable) {
         return boothRepository.findAllByConferenceId(conferenceId, pageable)
-                .map(BoothResponseDto::of);
+                .map(BoothResponseDto::from);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/synergy/backend/domain/booth/service/BoothServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/booth/service/BoothServiceImpl.java
@@ -6,10 +6,15 @@ import com.synergy.backend.domain.booth.dto.BoothRequestDto;
 import com.synergy.backend.domain.booth.dto.BoothResponseDto;
 import com.synergy.backend.domain.booth.entity.Booth;
 import com.synergy.backend.domain.booth.exception.NotFoundBoothException;
+import com.synergy.backend.domain.booth.repository.BoothParticipationRepository;
 import com.synergy.backend.domain.booth.repository.BoothRepository;
 import com.synergy.backend.domain.conference.entity.Conference;
 import com.synergy.backend.domain.conference.exception.NotFoundConference;
 import com.synergy.backend.domain.conference.repository.ConferenceRepository;
+import com.synergy.backend.domain.member.entity.Attendee;
+import com.synergy.backend.domain.member.entity.RoleType;
+import com.synergy.backend.domain.member.exception.NotFoundUserException;
+import com.synergy.backend.domain.member.repository.AttendeeRepository;
 import com.synergy.backend.domain.qrCode.service.QrService;
 import com.synergy.backend.global.util.file.dto.FileInformationDto;
 import com.synergy.backend.global.util.file.util.FileS3Util;
@@ -28,12 +33,14 @@ public class BoothServiceImpl implements BoothService {
 
     private final BoothRepository boothRepository;
     private final ConferenceRepository conferenceRepository;
+    private final BoothParticipationRepository boothParticipationRepository;
+    private final AttendeeRepository attendeeRepository;
     private final FileS3Util fileS3Util;
     private final QrService qrService;
 
     @Transactional
     @Override
-    public BoothDetailResponseDto createBooth(Long conferenceId, String router, BoothRequestDto request, MultipartFile imageFile) throws WriterException {
+    public void createBooth(Long conferenceId, String router, BoothRequestDto request, MultipartFile imageFile) throws WriterException {
         Conference conference = ifConferenceExists(conferenceId);
 
         String secretCode = UUID.randomUUID().toString();
@@ -57,8 +64,6 @@ public class BoothServiceImpl implements BoothService {
 
         FileInformationDto imageInfo = fileS3Util.uploadFile(imageFile);
         booth.updateImage(imageInfo);
-
-        return new BoothDetailResponseDto(booth);
     }
 
     @Transactional(readOnly = true)
@@ -70,12 +75,25 @@ public class BoothServiceImpl implements BoothService {
 
     @Transactional(readOnly = true)
     @Override
-    public BoothDetailResponseDto getBoothById(Long conferenceId, Long id) {
+    public BoothDetailResponseDto getBoothById(String identifier, RoleType role, Long conferenceId, Long id) {
         Booth booth = ifBoothExists(id);
+        Boolean isQRVerify = Boolean.FALSE;
+
         if (!booth.getConference().getId().equals(conferenceId)) {
             throw new NotFoundBoothException();
         }
-        return new BoothDetailResponseDto(booth);
+
+        try {
+            if(role.equals(RoleType.ATTENDEE)) {
+                Attendee attendee = findIfAttendeeExists(identifier);
+                boothParticipationRepository.existsByBoothIdAndAttendeeId(booth.getId(), attendee.getId())
+                        .orElseThrow(NotFoundBoothException::new);
+                isQRVerify = Boolean.TRUE;
+            }
+            return new BoothDetailResponseDto(booth, isQRVerify);
+        } catch (Exception e) {
+            return new BoothDetailResponseDto(booth, isQRVerify);
+        }
     }
 
     @Transactional
@@ -99,7 +117,7 @@ public class BoothServiceImpl implements BoothService {
                 imageInfo != null ? imageInfo.accessUrl() : booth.getImageUrl()
         );
 
-        return new BoothDetailResponseDto(booth);
+        return new BoothDetailResponseDto(booth, Boolean.FALSE);
     }
 
     @Transactional
@@ -120,5 +138,9 @@ public class BoothServiceImpl implements BoothService {
     private Booth ifBoothExists(Long boothId) {
         return boothRepository.findById(boothId)
                 .orElseThrow(NotFoundBoothException::new);
+    }
+
+    private Attendee findIfAttendeeExists(String identifier) {
+        return attendeeRepository.findByEmail(identifier).orElseThrow(NotFoundUserException::new);
     }
 }

--- a/src/main/java/com/synergy/backend/domain/booth/service/BoothServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/booth/service/BoothServiceImpl.java
@@ -48,6 +48,8 @@ public class BoothServiceImpl implements BoothService {
                 conference
         );
 
+        boothRepository.save(booth);
+
         String url = router + "/booth/" + booth.getId();
         byte[] qrCode = qrService.generateQRCode(url, secretCode);
         FileInformationDto qrInfo = fileS3Util.uploadQRCode(qrCode, booth.getCompanyName());
@@ -55,7 +57,6 @@ public class BoothServiceImpl implements BoothService {
 
         FileInformationDto imageInfo = fileS3Util.uploadFile(imageFile);
         booth.updateImage(imageInfo);
-        boothRepository.save(booth);
 
         return new BoothDetailResponseDto(booth);
     }

--- a/src/main/java/com/synergy/backend/domain/member/api/AuthController.java
+++ b/src/main/java/com/synergy/backend/domain/member/api/AuthController.java
@@ -135,6 +135,11 @@ public class AuthController {
 	@PostMapping("/email/verification/confirm")
 	public ApiResponse<?> emailVerificationConfirm(@Valid @RequestBody EmailVerificationConfirmDto request) {
 		mailService.mailVerificationConfirm(request.email(), request.code());
+		switch (request.purpose()) {
+			case UNLOCK_ACCOUNT -> authService.unlockAccountIfLocked(request.email());
+			case SIGNUP, PASSWORD_RESET -> {}
+		}
+
 		return ApiResponse.emptyOk();
 	}
 

--- a/src/main/java/com/synergy/backend/domain/member/api/dto/request/EmailVerificationConfirmDto.java
+++ b/src/main/java/com/synergy/backend/domain/member/api/dto/request/EmailVerificationConfirmDto.java
@@ -3,6 +3,7 @@ package com.synergy.backend.domain.member.api.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record EmailVerificationConfirmDto(
 	@NotBlank(message = "이메일은 필수입니다.")
@@ -12,6 +13,10 @@ public record EmailVerificationConfirmDto(
 
 	@NotBlank(message = "인증 코드는 필수입니다.")
 	@Schema(description = "이메일로 발송된 인증 코드", example = "493851")
-	String code
+	String code,
+
+	@NotNull
+	@Schema(description = "이메일로 발송된 인증 코드를 확인하는 목적", example = "SIGNUP")
+	VerificationPurpose purpose
 ) {
 }

--- a/src/main/java/com/synergy/backend/domain/member/api/dto/request/SignupAttendeeRequestDto.java
+++ b/src/main/java/com/synergy/backend/domain/member/api/dto/request/SignupAttendeeRequestDto.java
@@ -23,7 +23,7 @@ public record SignupAttendeeRequestDto(
 
 	@NotBlank(message = "비밀번호는 필수 입력 값입니다.")
 	@Size(min = 8, max = 20, message = "비밀번호는 8~20자 이내여야 합니다.")
-	@Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,20}$",
+	@Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d).{8,20}$",
 		message = "비밀번호는 영문자와 숫자를 포함해야 합니다.")
 	@Schema(description = "비밀번호 (영문자 + 숫자 포함 8~20 글자)", example = "abc12345")
 	String password,

--- a/src/main/java/com/synergy/backend/domain/member/api/dto/request/VerificationPurpose.java
+++ b/src/main/java/com/synergy/backend/domain/member/api/dto/request/VerificationPurpose.java
@@ -1,0 +1,10 @@
+package com.synergy.backend.domain.member.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "이메일 인증 요청/확인 목적", example = "SIGNUP")
+public enum VerificationPurpose {
+	SIGNUP,
+	PASSWORD_RESET,
+	UNLOCK_ACCOUNT
+}

--- a/src/main/java/com/synergy/backend/domain/member/api/dto/resposne/AttendeePointRankingResponseDto.java
+++ b/src/main/java/com/synergy/backend/domain/member/api/dto/resposne/AttendeePointRankingResponseDto.java
@@ -3,11 +3,13 @@ package com.synergy.backend.domain.member.api.dto.resposne;
 import com.synergy.backend.domain.member.entity.Attendee;
 
 public record AttendeePointRankingResponseDto(
+	Long attendeeId,
 	String attendeeName,
 	Integer totalPoints
 ) {
 	public static AttendeePointRankingResponseDto from(Attendee attendee) {
 		return new AttendeePointRankingResponseDto(
+			attendee.getId(),
 			attendee.getName(),
 			attendee.getTotalPoints()
 		);

--- a/src/main/java/com/synergy/backend/domain/member/api/dto/resposne/RecruiterMyInfoResponseDto.java
+++ b/src/main/java/com/synergy/backend/domain/member/api/dto/resposne/RecruiterMyInfoResponseDto.java
@@ -16,4 +16,10 @@ public record RecruiterMyInfoResponseDto(
 			recruiter.getResponsibility()
 		);
 	}
+
+	public static RecruiterMyInfoResponseDto from(String companyPhotoUrl, String recruiterName, String company,
+		String responsibility) {
+		return new RecruiterMyInfoResponseDto(
+			companyPhotoUrl, recruiterName, company, responsibility);
+	}
 }

--- a/src/main/java/com/synergy/backend/domain/member/entity/Attendee.java
+++ b/src/main/java/com/synergy/backend/domain/member/entity/Attendee.java
@@ -71,7 +71,7 @@ public class Attendee extends BaseEntity implements User {
 
 	// 계정 잠금 상태
 	@Column(nullable = false)
-	private boolean isLocked;
+	private boolean isLocked = false;
 
 	// 현재 포인트 합계
 	@Column(nullable = false)
@@ -275,5 +275,13 @@ public class Attendee extends BaseEntity implements User {
 
 	public void assignConference(Conference conference) {
 		this.conference = conference;
+	}
+
+	public void lockAccount() {
+		this.isLocked = true;
+	}
+
+	public void unlockAccount() {
+		this.isLocked = false;
 	}
 }

--- a/src/main/java/com/synergy/backend/domain/member/entity/Attendee.java
+++ b/src/main/java/com/synergy/backend/domain/member/entity/Attendee.java
@@ -69,6 +69,10 @@ public class Attendee extends BaseEntity implements User {
 	@Column(nullable = false)
 	private String phone;
 
+	// 계정 잠금 상태
+	@Column(nullable = false)
+	private boolean isLocked;
+
 	// 현재 포인트 합계
 	@Column(nullable = false)
 	private int totalPoints = 0;

--- a/src/main/java/com/synergy/backend/domain/member/exception/AccountLockedException.java
+++ b/src/main/java/com/synergy/backend/domain/member/exception/AccountLockedException.java
@@ -1,0 +1,11 @@
+package com.synergy.backend.domain.member.exception;
+
+import static com.synergy.backend.domain.member.exception.ErrorType.*;
+
+import com.synergy.backend.global.exception.BaseErrorException;
+
+public class AccountLockedException extends BaseErrorException {
+	public AccountLockedException() {
+		super(_ACCOUNT_LOCKED.getCode(), _ACCOUNT_LOCKED.getMessage());
+	}
+}

--- a/src/main/java/com/synergy/backend/domain/member/exception/ErrorType.java
+++ b/src/main/java/com/synergy/backend/domain/member/exception/ErrorType.java
@@ -26,6 +26,8 @@ public enum ErrorType {
 	_LIKE_NOT_FOUND(400, "해당 좋아요를 찾을 수 없습니다."),
 	_INVALID_ACCOUNT_INFORMATION(400, "입력하신 계정정보가 일치하지 않습니다."),
 	_SAME_AS_PREVIOUS_PASSWORD(400, "이전에 사용한 비밀번호와 동일한 비밀번호는 사용할 수 없습니다."),
+	_ACCOUNT_LOCKED(403, "계정이 잠겨있습니다. 이메일을 확인하거나 30분 후 재시도해주세요.")
+
 	;
 
 	private final int code;

--- a/src/main/java/com/synergy/backend/domain/member/service/AccountLockService.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AccountLockService.java
@@ -1,0 +1,7 @@
+package com.synergy.backend.domain.member.service;
+
+import com.synergy.backend.domain.member.entity.User;
+
+public interface AccountLockService {
+	void lockUserAccount(User user);
+}

--- a/src/main/java/com/synergy/backend/domain/member/service/AccountLockServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AccountLockServiceImpl.java
@@ -1,0 +1,38 @@
+package com.synergy.backend.domain.member.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.synergy.backend.domain.member.entity.Attendee;
+import com.synergy.backend.domain.member.entity.User;
+import com.synergy.backend.domain.member.repository.AttendeeRepository;
+import com.synergy.backend.global.mail.MailService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AccountLockServiceImpl implements AccountLockService {
+
+	private final AttendeeRepository attendeeRepository;
+	private final MailService mailService;
+
+	@Override
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void lockUserAccount(User user) {
+        /*
+            계정 잠금 조치
+                - 계정 islocked를 true 로 변경 (추가적인 인증 필요한 상태)
+                - 계정 가입한 이메일로 보안 코드 발송
+         */
+
+		//  트랜잭션 안에서 영속성 컨텍스트에 관리되는 객체
+		// REQUIRES_NEW: 별도 트랜잭션이므로 전달받은 객체가 deteched일 수 있음
+		Attendee attendee = attendeeRepository.findById(user.getId())
+			.orElseThrow(() -> new IllegalStateException("존재하지 않는 사용자입니다."));
+
+		attendee.lockAccount();
+		// mailService.sendVerificationCodeToMail(attendee.getEmail());
+	}
+}

--- a/src/main/java/com/synergy/backend/domain/member/service/AccountLockServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AccountLockServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.synergy.backend.domain.member.entity.Attendee;
 import com.synergy.backend.domain.member.entity.User;
+import com.synergy.backend.domain.member.exception.NotFoundUserException;
 import com.synergy.backend.domain.member.repository.AttendeeRepository;
 import com.synergy.backend.global.mail.MailService;
 
@@ -30,9 +31,9 @@ public class AccountLockServiceImpl implements AccountLockService {
 		//  트랜잭션 안에서 영속성 컨텍스트에 관리되는 객체
 		// REQUIRES_NEW: 별도 트랜잭션이므로 전달받은 객체가 deteched일 수 있음
 		Attendee attendee = attendeeRepository.findById(user.getId())
-			.orElseThrow(() -> new IllegalStateException("존재하지 않는 사용자입니다."));
+			.orElseThrow(NotFoundUserException::new);
 
 		attendee.lockAccount();
-		// mailService.sendVerificationCodeToMail(attendee.getEmail());
+		mailService.sendVerificationCodeToMail(attendee.getEmail());
 	}
 }

--- a/src/main/java/com/synergy/backend/domain/member/service/AccountLockServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AccountLockServiceImpl.java
@@ -34,6 +34,7 @@ public class AccountLockServiceImpl implements AccountLockService {
 			.orElseThrow(NotFoundUserException::new);
 
 		attendee.lockAccount();
+		attendeeRepository.save(attendee);
 		mailService.sendVerificationCodeToMail(attendee.getEmail());
 	}
 }

--- a/src/main/java/com/synergy/backend/domain/member/service/AccountLockServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AccountLockServiceImpl.java
@@ -1,9 +1,11 @@
 package com.synergy.backend.domain.member.service;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.synergy.backend.domain.auth.AccountLockedEvent;
 import com.synergy.backend.domain.member.entity.Attendee;
 import com.synergy.backend.domain.member.entity.User;
 import com.synergy.backend.domain.member.exception.NotFoundUserException;
@@ -17,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 public class AccountLockServiceImpl implements AccountLockService {
 
 	private final AttendeeRepository attendeeRepository;
-	private final MailService mailService;
+	private final ApplicationEventPublisher applicationEventPublisher;
 
 	@Override
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -35,6 +37,8 @@ public class AccountLockServiceImpl implements AccountLockService {
 
 		attendee.lockAccount();
 		attendeeRepository.save(attendee);
-		mailService.sendVerificationCodeToMail(attendee.getEmail());
+
+		// 이벤트 발행
+		applicationEventPublisher.publishEvent(new AccountLockedEvent(attendee.getEmail()));
 	}
 }

--- a/src/main/java/com/synergy/backend/domain/member/service/AttendeeServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AttendeeServiceImpl.java
@@ -79,8 +79,17 @@ public class AttendeeServiceImpl implements AttendeeService {
 	public void addJobInfoDetails(Long id, JobInfoDetailsRequestDto request, MultipartFile profileImage) {
 		Attendee attendee = findAttendeeById(id);
 
+		FileInformationDto uploadedImage = null;
 		if (profileImage != null && !profileImage.isEmpty()) {
-			attendee.addImage(fileS3Util.uploadFile(profileImage));
+			try {
+				uploadedImage = fileS3Util.uploadFile(profileImage);
+			} catch (Exception e) {
+				throw new EmptyImageFileException();
+			}
+		}
+
+		if (uploadedImage != null) {
+			attendee.addImage(uploadedImage);
 		}
 
 		attendee.updateJobInfoDetails(

--- a/src/main/java/com/synergy/backend/domain/member/service/AuthService.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AuthService.java
@@ -5,6 +5,8 @@ import com.synergy.backend.domain.member.api.dto.resposne.SignupAttendeeResponse
 import com.synergy.backend.domain.member.vo.TokenWithRefreshToken;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 
 public interface AuthService {
 	SignupAttendeeResponseDto registerAttendee(@Valid SignupAttendeeRequestDto request);
@@ -20,4 +22,6 @@ public interface AuthService {
 	TokenWithRefreshToken reissueRefreshToken(String refreshToken);
 
 	void logout(String refreshToken);
+
+	void unlockAccountIfLocked(@NotBlank(message = "이메일은 필수입니다.") @Email String email);
 }

--- a/src/main/java/com/synergy/backend/domain/member/service/AuthService.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AuthService.java
@@ -1,5 +1,7 @@
 package com.synergy.backend.domain.member.service;
 
+import javax.security.auth.login.AccountLockedException;
+
 import com.synergy.backend.domain.member.api.dto.request.SignupAttendeeRequestDto;
 import com.synergy.backend.domain.member.api.dto.resposne.SignupAttendeeResponseDto;
 import com.synergy.backend.domain.member.vo.TokenWithRefreshToken;
@@ -9,7 +11,7 @@ import jakarta.validation.Valid;
 public interface AuthService {
 	SignupAttendeeResponseDto registerAttendee(@Valid SignupAttendeeRequestDto request);
 
-	TokenWithRefreshToken loginAsAttendee(String email, String password);
+	TokenWithRefreshToken loginAsAttendee(String email, String password) throws AccountLockedException;
 
 	TokenWithRefreshToken loginAsAdminOrRecruiter(String authCode);
 

--- a/src/main/java/com/synergy/backend/domain/member/service/AuthService.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AuthService.java
@@ -1,7 +1,5 @@
 package com.synergy.backend.domain.member.service;
 
-import javax.security.auth.login.AccountLockedException;
-
 import com.synergy.backend.domain.member.api.dto.request.SignupAttendeeRequestDto;
 import com.synergy.backend.domain.member.api.dto.resposne.SignupAttendeeResponseDto;
 import com.synergy.backend.domain.member.vo.TokenWithRefreshToken;
@@ -11,7 +9,7 @@ import jakarta.validation.Valid;
 public interface AuthService {
 	SignupAttendeeResponseDto registerAttendee(@Valid SignupAttendeeRequestDto request);
 
-	TokenWithRefreshToken loginAsAttendee(String email, String password) throws AccountLockedException;
+	TokenWithRefreshToken loginAsAttendee(String email, String password);
 
 	TokenWithRefreshToken loginAsAdminOrRecruiter(String authCode);
 

--- a/src/main/java/com/synergy/backend/domain/member/service/AuthServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AuthServiceImpl.java
@@ -67,9 +67,8 @@ public class AuthServiceImpl implements AuthService {
 		Attendee attendee = Attendee.of(request.email(), encodePassword(request.password()), request.name(),
 			request.phone());
 
-		if (conference != null) {
-			attendee.assignConference(conference);
-		}
+		attendee.assignConference(conference);
+
 		attendeeRepository.save(attendee);
 
 		pointService.addSignupPoint(attendee.getId());
@@ -87,7 +86,7 @@ public class AuthServiceImpl implements AuthService {
 		if (attendee.isLocked()) {
 			// // Redis 키가 존재하는지 확인
 			if (loginFailedRepository.exists(email)) {
-			// 	// 아직 TTL 남아있음 → 계속 잠금 유지
+				// 	// 아직 TTL 남아있음 → 계속 잠금 유지
 				throw new AccountLockedException();
 			} else {
 				attendee.unlockAccount();

--- a/src/main/java/com/synergy/backend/domain/member/service/AuthServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AuthServiceImpl.java
@@ -15,6 +15,7 @@ import com.synergy.backend.domain.member.api.dto.resposne.SignupAttendeeResponse
 import com.synergy.backend.domain.member.api.dto.resposne.TokenResponseDto;
 import com.synergy.backend.domain.member.entity.Attendee;
 import com.synergy.backend.domain.member.entity.User;
+import com.synergy.backend.domain.member.exception.AccountLockedException;
 import com.synergy.backend.domain.member.exception.DuplicateEmailException;
 import com.synergy.backend.domain.member.exception.InvalidAccountInformationException;
 import com.synergy.backend.domain.member.exception.InvalidAuthCodeException;
@@ -77,10 +78,22 @@ public class AuthServiceImpl implements AuthService {
 		return SignupAttendeeResponseDto.from(attendee);
 	}
 
-	@Transactional(readOnly = true)
+	@Transactional
 	@Override
 	public TokenWithRefreshToken loginAsAttendee(String email, String rawPassword) {
 		Attendee attendee = findAttendeeByEmail(email);
+
+		// 계정 잠김 상태인지 확인
+		if (attendee.isLocked()) {
+			// // Redis 키가 존재하는지 확인
+			// if (loginFailedRepository.exists(email)) {
+			// 	// 아직 TTL 남아있음 → 계속 잠금 유지
+				throw new AccountLockedException();
+			// } else {
+			// 	attendee.unlockAccount();
+			// 	attendeeRepository.save(attendee);
+			// }
+		}
 
 		if (!isPasswordMatch(rawPassword, attendee.getPassword())) {
 			countLoginFailed(attendee);

--- a/src/main/java/com/synergy/backend/domain/member/service/AuthServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AuthServiceImpl.java
@@ -168,6 +168,17 @@ public class AuthServiceImpl implements AuthService {
 		tokenService.deleteRefreshToken(identifier);
 	}
 
+	@Override
+	public void unlockAccountIfLocked(String email) {
+		attendeeRepository.findByEmail(email).ifPresent(attendee -> {
+			if (attendee.isLocked()) {
+				attendee.unlockAccount();
+				attendeeRepository.save(attendee);
+				loginFailedRepository.delete(email);
+			}
+		});
+	}
+
 	private Attendee findAttendeeByEmail(String email) {
 		return attendeeRepository.findByEmail(email).orElseThrow(NotFoundUserException::new);
 	}

--- a/src/main/java/com/synergy/backend/domain/member/service/AuthServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AuthServiceImpl.java
@@ -86,13 +86,13 @@ public class AuthServiceImpl implements AuthService {
 		// 계정 잠김 상태인지 확인
 		if (attendee.isLocked()) {
 			// // Redis 키가 존재하는지 확인
-			// if (loginFailedRepository.exists(email)) {
+			if (loginFailedRepository.exists(email)) {
 			// 	// 아직 TTL 남아있음 → 계속 잠금 유지
 				throw new AccountLockedException();
-			// } else {
-			// 	attendee.unlockAccount();
-			// 	attendeeRepository.save(attendee);
-			// }
+			} else {
+				attendee.unlockAccount();
+				attendeeRepository.save(attendee);
+			}
 		}
 
 		if (!isPasswordMatch(rawPassword, attendee.getPassword())) {
@@ -187,6 +187,7 @@ public class AuthServiceImpl implements AuthService {
 		if (attemptCount >= MAX_ATTEMPT_COUNT) {
 			accountLockService.lockUserAccount(attendee);
 			loginFailedRepository.delete(attendee.getEmail()); // 계정 잠금 후 실패 횟수 초기화
+			throw new AccountLockedException();
 		}
 	}
 

--- a/src/main/java/com/synergy/backend/domain/member/service/AuthServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AuthServiceImpl.java
@@ -191,7 +191,7 @@ public class AuthServiceImpl implements AuthService {
 	}
 
 	private void countLoginFailed(Attendee attendee) {
-		Long attemptCount = incrementFailedCount(attendee);
+		Integer attemptCount = incrementFailedCount(attendee);
 
 		log.info("attemptCount : {}", attemptCount);
 
@@ -202,7 +202,7 @@ public class AuthServiceImpl implements AuthService {
 		}
 	}
 
-	private Long incrementFailedCount(Attendee attendee) {
+	private Integer incrementFailedCount(Attendee attendee) {
 		if (loginFailedRepository.getValues(attendee.getEmail()) == null) {
 			loginFailedRepository.setValue(attendee.getEmail(), INIT_LOGIN_TRIAL_COUNT);
 		}

--- a/src/main/java/com/synergy/backend/domain/member/service/AuthServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/member/service/AuthServiceImpl.java
@@ -1,9 +1,12 @@
 package com.synergy.backend.domain.member.service;
 
+import static com.synergy.backend.domain.auth.LoginFailedRepository.*;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.synergy.backend.domain.auth.LoginFailedRepository;
 import com.synergy.backend.domain.conference.entity.Conference;
 import com.synergy.backend.domain.conference.exception.InvalidTicketCodeException;
 import com.synergy.backend.domain.conference.repository.ConferenceRepository;
@@ -49,6 +52,8 @@ public class AuthServiceImpl implements AuthService {
 	private final MailService mailService;
 	private final TokenService tokenService;
 	private final CustomUserDetailsService userDetailsService;
+	private final LoginFailedRepository loginFailedRepository;
+	private final AccountLockService accountLockService;
 
 	@Transactional
 	@Override
@@ -78,6 +83,7 @@ public class AuthServiceImpl implements AuthService {
 		Attendee attendee = findAttendeeByEmail(email);
 
 		if (!isPasswordMatch(rawPassword, attendee.getPassword())) {
+			countLoginFailed(attendee);
 			throw new UnauthorizedException();
 		}
 
@@ -158,6 +164,24 @@ public class AuthServiceImpl implements AuthService {
 			.<User>map(admin -> admin)
 			.or(() -> recruiterRepository.findByRecruiterAuthCode(authCode))
 			.orElseThrow(InvalidAuthCodeException::new);
+	}
+
+	private void countLoginFailed(Attendee attendee) {
+		Long attemptCount = incrementFailedCount(attendee);
+
+		log.info("attemptCount : {}", attemptCount);
+
+		if (attemptCount >= MAX_ATTEMPT_COUNT) {
+			accountLockService.lockUserAccount(attendee);
+			loginFailedRepository.delete(attendee.getEmail()); // 계정 잠금 후 실패 횟수 초기화
+		}
+	}
+
+	private Long incrementFailedCount(Attendee attendee) {
+		if (loginFailedRepository.getValues(attendee.getEmail()) == null) {
+			loginFailedRepository.setValue(attendee.getEmail(), INIT_LOGIN_TRIAL_COUNT);
+		}
+		return loginFailedRepository.increment(attendee.getEmail());
 	}
 
 	private void validateSignupRequest(SignupAttendeeRequestDto request) {

--- a/src/main/java/com/synergy/backend/global/config/RedisConfig.java
+++ b/src/main/java/com/synergy/backend/global/config/RedisConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -14,6 +15,15 @@ public class RedisConfig {
 		template.setConnectionFactory(connectionFactory);
 		template.setKeySerializer(new StringRedisSerializer());
 		template.setValueSerializer(new StringRedisSerializer());
+		return template;
+	}
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplateObject(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
 		return template;
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,7 +24,7 @@ spring:
 
   sql:
     init:
-      mode: never
+      mode: always
   #      data-locations: ""
 
   cloud:

--- a/src/main/resources/data-test.sql
+++ b/src/main/resources/data-test.sql
@@ -70,14 +70,14 @@ INSERT INTO recruiter (recruiter_auth_code, company, responsibility, name) VALUE
 INSERT INTO recruiter (recruiter_auth_code, company, responsibility, name) VALUES ( 'RC67890', 'OpenStack Korea', 'HR팀 매니저', '김주은');
 
 -- 참가자 기본 데이터
-INSERT INTO attendee (email, password, name, phone, total_points, membership_level_type, profile_image_url, conference_id)
+INSERT INTO attendee (email, password, name, phone, total_points, membership_level_type, profile_image_url, conference_id, is_locked)
 VALUES
-    ('jiwon.kim@example.com', '$2a$10$aO4mzbreIOHJiJDgPaUtG.BS81l7i92I2.D2qkwvM5hvUB8BGBsk2', '김지원', '01012345678', 250, 'BRONZE', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%80%E1%85%B5%E1%86%B7%E1%84%8C%E1%85%B5%E1%84%8B%E1%85%AF%E1%86%AB.png', 1),
-    ('youngho.choi@example.com', '$2a$10$hashedpassword2', '최영호', '01056781234', 1200, 'GOLD', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%8E%E1%85%AC%E1%84%8B%E1%85%A7%E1%86%BC%E1%84%92%E1%85%A9.png', 1),
-    ('seoyeon.jung@example.com', '$2a$10$hashedpassword3', '정서연', '01055556666', 1200, 'GOLD', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%8C%E1%85%A5%E1%86%BC%E1%84%89%E1%85%A5%E1%84%8B%E1%85%A7%E1%86%AB.png', 1),
-    ('sihyung.park@example.com', '$2a$10$hashedpassword4', '박시형', '01077778888', 300, 'SILVER', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%87%E1%85%A1%E1%86%A8%E1%84%89%E1%85%B5%E1%84%92%E1%85%A7%E1%86%BC.png', 1),
-    ('dayoung.lee@example.com', '$2a$10$hashedpassword5', '이다영', '01099990000', 1500, 'GOLD', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%8B%E1%85%B5%E1%84%83%E1%85%A1%E1%84%8B%E1%85%A7%E1%86%BC.png', 1),
-    ('dahye.kim@example.com', '$2a$10$hashedpassword6', '김다혜', '01011112222', 50, 'DEFAULT', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%80%E1%85%B5%E1%86%B7%E1%84%83%E1%85%A1%E1%84%92%E1%85%A8.png', 1);
+    ('jiwon.kim@example.com', '$2a$10$aO4mzbreIOHJiJDgPaUtG.BS81l7i92I2.D2qkwvM5hvUB8BGBsk2', '김지원', '01012345678', 250, 'BRONZE', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%80%E1%85%B5%E1%86%B7%E1%84%8C%E1%85%B5%E1%84%8B%E1%85%AF%E1%86%AB.png', 1, 0),
+    ('youngho.choi@example.com', '$2a$10$hashedpassword2', '최영호', '01056781234', 1200, 'GOLD', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%8E%E1%85%AC%E1%84%8B%E1%85%A7%E1%86%BC%E1%84%92%E1%85%A9.png', 1, 0),
+    ('seoyeon.jung@example.com', '$2a$10$hashedpassword3', '정서연', '01055556666', 1200, 'GOLD', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%8C%E1%85%A5%E1%86%BC%E1%84%89%E1%85%A5%E1%84%8B%E1%85%A7%E1%86%AB.png', 1, 0),
+    ('sihyung.park@example.com', '$2a$10$hashedpassword4', '박시형', '01077778888', 300, 'SILVER', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%87%E1%85%A1%E1%86%A8%E1%84%89%E1%85%B5%E1%84%92%E1%85%A7%E1%86%BC.png', 1, 0),
+    ('dayoung.lee@example.com', '$2a$10$hashedpassword5', '이다영', '01099990000', 1500, 'GOLD', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%8B%E1%85%B5%E1%84%83%E1%85%A1%E1%84%8B%E1%85%A7%E1%86%BC.png', 1, 0),
+    ('dahye.kim@example.com', '$2a$10$hashedpassword6', '김다혜', '01011112222', 50, 'DEFAULT', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%80%E1%85%B5%E1%86%B7%E1%84%83%E1%85%A1%E1%84%92%E1%85%A8.png', 1, 0);
 
 -- 김지원 (attendee_id = 1) → 수도권, 부산
 INSERT INTO attendee_desired_work_region (attendee_id, desired_work_region) VALUES (1, 0); -- CAPITAL_AREA

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -73,14 +73,14 @@ INSERT INTO recruiter (recruiter_id, recruiter_auth_code, company, responsibilit
 INSERT INTO recruiter (recruiter_id, recruiter_auth_code, company, responsibility, name, company_photo_url) VALUES (2, 'RC67890', 'OpenStack Korea', 'HR팀 매니저', '김주은', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/boothlogo-rectangle/OpenStackKorea.png');
 
 -- 참가자 기본 데이터
-INSERT INTO attendee (email, password, name, phone, total_points, membership_level_type, profile_image_url, conference_id)
+INSERT INTO attendee (email, password, name, phone, total_points, membership_level_type, profile_image_url, conference_id, is_locked)
 VALUES
-    ('jiwon.kim@example.com', '$2a$10$aO4mzbreIOHJiJDgPaUtG.BS81l7i92I2.D2qkwvM5hvUB8BGBsk2', '김지원', '01012345678', 250, 'BRONZE', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%80%E1%85%B5%E1%86%B7%E1%84%8C%E1%85%B5%E1%84%8B%E1%85%AF%E1%86%AB.png', 1),
-    ('youngho.choi@example.com', '$2a$10$hashedpassword2', '최영호', '01056781234', 1200, 'GOLD', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%8E%E1%85%AC%E1%84%8B%E1%85%A7%E1%86%BC%E1%84%92%E1%85%A9.png', 1),
-    ('seoyeon.jung@example.com', '$2a$10$hashedpassword3', '정서연', '01055556666', 1200, 'GOLD', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%8C%E1%85%A5%E1%86%BC%E1%84%89%E1%85%A5%E1%84%8B%E1%85%A7%E1%86%AB.png', 1),
-    ('sihyung.park@example.com', '$2a$10$hashedpassword4', '박시형', '01077778888', 300, 'SILVER', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%87%E1%85%A1%E1%86%A8%E1%84%89%E1%85%B5%E1%84%92%E1%85%A7%E1%86%BC.png', 1),
-    ('dayoung.lee@example.com', '$2a$10$hashedpassword5', '이다영', '01099990000', 1500, 'GOLD', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%8B%E1%85%B5%E1%84%83%E1%85%A1%E1%84%8B%E1%85%A7%E1%86%BC.png', 1),
-    ('dahye.kim@example.com', '$2a$10$hashedpassword6', '김다혜', '01011112222', 50, 'DEFAULT', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%80%E1%85%B5%E1%86%B7%E1%84%83%E1%85%A1%E1%84%92%E1%85%A8.png', 1);
+    ('jiwon.kim@example.com', '$2a$10$aO4mzbreIOHJiJDgPaUtG.BS81l7i92I2.D2qkwvM5hvUB8BGBsk2', '김지원', '01012345678', 250, 'BRONZE', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%80%E1%85%B5%E1%86%B7%E1%84%8C%E1%85%B5%E1%84%8B%E1%85%AF%E1%86%AB.png', 1, 0),
+    ('youngho.choi@example.com', '$2a$10$hashedpassword2', '최영호', '01056781234', 1200, 'GOLD', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%8E%E1%85%AC%E1%84%8B%E1%85%A7%E1%86%BC%E1%84%92%E1%85%A9.png', 1, 0),
+    ('seoyeon.jung@example.com', '$2a$10$hashedpassword3', '정서연', '01055556666', 1200, 'GOLD', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%8C%E1%85%A5%E1%86%BC%E1%84%89%E1%85%A5%E1%84%8B%E1%85%A7%E1%86%AB.png', 1, 0),
+    ('sihyung.park@example.com', '$2a$10$hashedpassword4', '박시형', '01077778888', 300, 'SILVER', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%87%E1%85%A1%E1%86%A8%E1%84%89%E1%85%B5%E1%84%92%E1%85%A7%E1%86%BC.png', 1, 0),
+    ('dayoung.lee@example.com', '$2a$10$hashedpassword5', '이다영', '01099990000', 1500, 'GOLD', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%8B%E1%85%B5%E1%84%83%E1%85%A1%E1%84%8B%E1%85%A7%E1%86%BC.png', 1, 0),
+    ('dahye.kim@example.com', '$2a$10$hashedpassword6', '김다혜', '01011112222', 50, 'DEFAULT', 'https://synergy-conference-bucket.s3.ap-northeast-2.amazonaws.com/all/dummydata+v.0.1/profile/%E1%84%80%E1%85%B5%E1%86%B7%E1%84%83%E1%85%A1%E1%84%92%E1%85%A8.png', 1, 0);
 
 -- 김지원 (attendee_id = 1) → 수도권, 부산
 INSERT INTO attendee_desired_work_region (attendee_id, desired_work_region) VALUES (1, 0); -- CAPITAL_AREA

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -6,8 +6,8 @@ VALUES
 -- 부스
 INSERT INTO booth (conference_id, company_name, company_type, booth_location, booth_number, progress_date, booth_description, image_key, image_url, qr_key, qr_url, secret_code)
 VALUES (1, 'CodeSphere', 'YourCompanyType', 'C HALL', '101C', '3021-10-11', '클라우드서비스: 글로벌 IT 기업 CodeSphere에서 React 기반 프론트엔드 엔지니어와 클라우드 기반 백엔드 엔지니어를 채용합니다. TypeScript, Node.js, Kubernetes 경험자를 환영합니다.', 'default-key', 'https://default-image-url.com/default.jpg', 'default-qr-key', 'https://default-qr-url.com/default-qr.png', 'Bdefault-secret-code'),
-       (1, 'DevNest', 'IT', 'A ZONE', '201A', '3021-10-11', 'DevNest는 다양한 SaaS 솔루션을 개발하는 스타트업으로, 백엔드(Java, Spring) 및 클라우드 인프라 엔지니어를 채용 중입니다. 열정적인 동료들과 함께 일할 개발자를 기다립니다.', 'devnest-key', 'https://default-image-url.com/devnest.jpg', 'devnest-qr-key', 'https://default-qr-url.com/devnest.png', 'Bdevnest-secret-code'),
-       (1, 'NextBridge', 'AI', 'B ZONE', '302B', '3021-10-11', 'NextBridge는 AI 기반 교육 플랫폼을 개발 중이며, 머신러닝 엔지니어와 프론트엔드(React) 개발자를 채용하고 있습니다. 기술로 세상을 연결하는 기업입니다.', 'nextbridge-key', 'https://default-image-url.com/nextbridge.jpg', 'nextbridge-qr-key', 'https://default-qr-url.com/nextbridge.png', 'Bnextbridge-secret-code');
+       (1, 'DevNest', 'IT', 'A ZONE', '201A', '2025-03-30', 'DevNest는 다양한 SaaS 솔루션을 개발하는 스타트업으로, 백엔드(Java, Spring) 및 클라우드 인프라 엔지니어를 채용 중입니다. 열정적인 동료들과 함께 일할 개발자를 기다립니다.', 'devnest-key', 'https://default-image-url.com/devnest.jpg', 'devnest-qr-key', 'https://default-qr-url.com/devnest.png', 'Bdevnest-secret-code'),
+       (1, 'NextBridge', 'AI', 'B ZONE', '302B', '2025-03-30', 'NextBridge는 AI 기반 교육 플랫폼을 개발 중이며, 머신러닝 엔지니어와 프론트엔드(React) 개발자를 채용하고 있습니다. 기술로 세상을 연결하는 기업입니다.', 'nextbridge-key', 'https://default-image-url.com/nextbridge.jpg', 'nextbridge-qr-key', 'https://default-qr-url.com/nextbridge.png', 'Bnextbridge-secret-code');
 
 -- 세션
 INSERT INTO session (maximum, progress_date, conference_id, end_time, start_time, speaker_position, speaker, title, description, qr_key, qr_url, image_key, image_url, secret_code)

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -5,9 +5,9 @@ VALUES
 
 -- 부스
 INSERT INTO booth (conference_id, company_name, company_type, booth_location, booth_number, progress_date, booth_description, image_key, image_url, qr_key, qr_url, secret_code)
-VALUES (1, 'CodeSphere', 'YourCompanyType', 'C HALL', '101C', '3021-10-11', '클라우드서비스: 글로벌 IT 기업 CodeSphere에서 React 기반 프론트엔드 엔지니어와 클라우드 기반 백엔드 엔지니어를 채용합니다. TypeScript, Node.js, Kubernetes 경험자를 환영합니다.', 'default-key', 'https://default-image-url.com/default.jpg', 'default-qr-key', 'https://default-qr-url.com/default-qr.png', 'Bdefault-secret-code'),
+VALUES (1, 'CodeSphere', 'YourCompanyType', 'C HALL', '101C', '2025-03-30', '클라우드서비스: 글로벌 IT 기업 CodeSphere에서 React 기반 프론트엔드 엔지니어와 클라우드 기반 백엔드 엔지니어를 채용합니다. TypeScript, Node.js, Kubernetes 경험자를 환영합니다.', 'default-key', 'https://default-image-url.com/default.jpg', 'default-qr-key', 'https://default-qr-url.com/default-qr.png', 'Bdefault-secret-code'),
        (1, 'DevNest', 'IT', 'A ZONE', '201A', '2025-03-30', 'DevNest는 다양한 SaaS 솔루션을 개발하는 스타트업으로, 백엔드(Java, Spring) 및 클라우드 인프라 엔지니어를 채용 중입니다. 열정적인 동료들과 함께 일할 개발자를 기다립니다.', 'devnest-key', 'https://default-image-url.com/devnest.jpg', 'devnest-qr-key', 'https://default-qr-url.com/devnest.png', 'Bdevnest-secret-code'),
-       (1, 'NextBridge', 'AI', 'B ZONE', '302B', '2025-03-30', 'NextBridge는 AI 기반 교육 플랫폼을 개발 중이며, 머신러닝 엔지니어와 프론트엔드(React) 개발자를 채용하고 있습니다. 기술로 세상을 연결하는 기업입니다.', 'nextbridge-key', 'https://default-image-url.com/nextbridge.jpg', 'nextbridge-qr-key', 'https://default-qr-url.com/nextbridge.png', 'Bnextbridge-secret-code');
+       (1, 'NextBridge', 'AI', 'B ZONE', '302B', '2025-03-31', 'NextBridge는 AI 기반 교육 플랫폼을 개발 중이며, 머신러닝 엔지니어와 프론트엔드(React) 개발자를 채용하고 있습니다. 기술로 세상을 연결하는 기업입니다.', 'nextbridge-key', 'https://default-image-url.com/nextbridge.jpg', 'nextbridge-qr-key', 'https://default-qr-url.com/nextbridge.png', 'Bnextbridge-secret-code');
 
 -- 세션
 INSERT INTO session (maximum, progress_date, conference_id, end_time, start_time, speaker_position, speaker, title, description, qr_key, qr_url, image_key, image_url, secret_code)

--- a/src/test/java/com/synergy/backend/domain/booth/controller/BoothControllerTest.java
+++ b/src/test/java/com/synergy/backend/domain/booth/controller/BoothControllerTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.mock;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
@@ -51,7 +50,8 @@ class BoothControllerTest extends ControllerTestSupport {
                 requestDto.progressDate(),
                 requestDto.boothDescription(),
                 "https://qr-url.com/booth123",
-                "https://image-url.com/booth123"
+                "https://image-url.com/booth123",
+                Boolean.FALSE
         );
 
         MockMultipartFile imageFile = new MockMultipartFile(
@@ -63,8 +63,7 @@ class BoothControllerTest extends ControllerTestSupport {
                 objectMapper.writeValueAsBytes(requestDto)
         );
 
-        given(boothService.createBooth(eq(conferenceId), eq(router), any(BoothRequestDto.class), any(MultipartFile.class)))
-                .willReturn(responseDto);
+        boothService.createBooth(eq(conferenceId), eq(router), any(BoothRequestDto.class), any(MultipartFile.class));
 
         given(jwtProvider.validateAccessToken(anyString())).willReturn(true);
         given(jwtProvider.getIdentifierFromToken(anyString())).willReturn("AUTH1");
@@ -80,9 +79,7 @@ class BoothControllerTest extends ControllerTestSupport {
                         .contentType(MediaType.MULTIPART_FORM_DATA)
                 )
                 .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.id").value(10L))
-                .andExpect(jsonPath("$.data.companyName").value("CodeSphere"));
+                .andExpect(status().isOk());
     }
 
 

--- a/src/test/java/com/synergy/backend/domain/booth/controller/BoothControllerTest.java
+++ b/src/test/java/com/synergy/backend/domain/booth/controller/BoothControllerTest.java
@@ -49,7 +49,6 @@ class BoothControllerTest extends ControllerTestSupport {
                 requestDto.boothNumber(),
                 requestDto.progressDate(),
                 requestDto.boothDescription(),
-                "https://qr-url.com/booth123",
                 "https://image-url.com/booth123",
                 Boolean.FALSE
         );

--- a/src/test/java/com/synergy/backend/domain/booth/repository/querydsl/BoothRepositoryImplTest.java
+++ b/src/test/java/com/synergy/backend/domain/booth/repository/querydsl/BoothRepositoryImplTest.java
@@ -1,6 +1,6 @@
 package com.synergy.backend.domain.booth.repository.querydsl;
 
-import com.synergy.backend.domain.booth.dto.BoothParticipationResponseDto;
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationResponseDto;
 import com.synergy.backend.domain.booth.repository.BoothRepository;
 import com.synergy.backend.domain.conference.entity.Conference;
 import com.synergy.backend.domain.conference.repository.ConferenceRepository;

--- a/src/test/java/com/synergy/backend/domain/booth/repository/querydsl/BoothRepositoryImplTest.java
+++ b/src/test/java/com/synergy/backend/domain/booth/repository/querydsl/BoothRepositoryImplTest.java
@@ -1,6 +1,6 @@
 package com.synergy.backend.domain.booth.repository.querydsl;
 
-import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationResponseDto;
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationInterestedResponseDto;
 import com.synergy.backend.domain.booth.repository.BoothRepository;
 import com.synergy.backend.domain.conference.entity.Conference;
 import com.synergy.backend.domain.conference.repository.ConferenceRepository;
@@ -30,7 +30,7 @@ class BoothRepositoryImplTest extends IntegrationSupportTest {
                 .orElseThrow(() -> new IllegalStateException("data-test.sql 이 실행되지 않았습니다."));
 
         // when
-        List<BoothParticipationResponseDto> result = boothRepository.searchBoothParticipation(savedConference.getId());
+        List<BoothParticipationInterestedResponseDto> result = boothRepository.searchBoothParticipation(savedConference.getId());
 
         // then
         assertThat(result)

--- a/src/test/java/com/synergy/backend/domain/booth/service/BoothServiceImplTest.java
+++ b/src/test/java/com/synergy/backend/domain/booth/service/BoothServiceImplTest.java
@@ -9,7 +9,10 @@ import com.synergy.backend.domain.booth.exception.NotFoundBoothException;
 import com.synergy.backend.domain.booth.repository.BoothRepository;
 import com.synergy.backend.domain.conference.entity.Conference;
 import com.synergy.backend.domain.conference.repository.ConferenceRepository;
+import com.synergy.backend.domain.member.entity.RoleType;
 import com.synergy.backend.domain.qrCode.service.QrService;
+import com.synergy.backend.global.jwt.JwtProvider;
+import com.synergy.backend.global.security.CustomUserDetailsService;
 import com.synergy.backend.global.util.file.dto.FileInformationDto;
 import com.synergy.backend.global.util.file.util.FileS3Util;
 import org.junit.jupiter.api.DisplayName;
@@ -19,6 +22,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.*;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -50,6 +56,11 @@ public class BoothServiceImplTest {
     @Mock
     private MultipartFile mockImageFile;
 
+    @MockitoBean
+    JwtProvider jwtProvider;
+    @MockitoBean
+    CustomUserDetailsService userDetailsService;
+
     @InjectMocks
     private BoothServiceImpl boothService;
 
@@ -77,11 +88,10 @@ public class BoothServiceImplTest {
         given(fileS3Util.uploadFile(any())).willReturn(imageDto);
 
         // when
-        BoothDetailResponseDto response = boothService.createBooth(conferenceId, router, request, mockImageFile);
+        boothService.createBooth(conferenceId, router, request, mockImageFile);
 
         // then
-        assertThat(response).isNotNull();
-        assertThat(response.companyName()).isEqualTo("부스A");
+        assertThat(boothRepository).isNotNull();
     }
 
     @DisplayName("컨퍼런스 ID로 모든 부스를 조회합니다.")
@@ -104,6 +114,7 @@ public class BoothServiceImplTest {
 
     @DisplayName("부스를 ID로 조회합니다.")
     @Test
+    @WithMockUser(username = "ATTENDEE1", roles = {"ATTENDEE"})
     void getBoothById() {
         // given
         Long conferenceId = 1L;
@@ -117,7 +128,7 @@ public class BoothServiceImplTest {
         when(boothRepository.findById(boothId)).thenReturn(Optional.of(booth));
 
         // when
-        BoothDetailResponseDto response = boothService.getBoothById(conferenceId, boothId);
+        BoothDetailResponseDto response = boothService.getBoothById("admin1", RoleType.ADMIN, conferenceId, boothId);
 
         // then
         assertThat(response).isNotNull();
@@ -133,7 +144,7 @@ public class BoothServiceImplTest {
         when(boothRepository.findById(boothId)).thenReturn(Optional.empty());
 
         // when
-        Throwable thrown = catchThrowable(() -> boothService.getBoothById(conferenceId, boothId));
+        Throwable thrown = catchThrowable(() -> boothService.getBoothById("admin1", RoleType.ADMIN, conferenceId, boothId));
 
         // then
         assertThat(thrown).isInstanceOf(NotFoundBoothException.class);

--- a/src/test/java/com/synergy/backend/domain/member/api/AdminControllerTest.java
+++ b/src/test/java/com/synergy/backend/domain/member/api/AdminControllerTest.java
@@ -1,0 +1,99 @@
+package com.synergy.backend.domain.member.api;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import com.synergy.backend.domain.member.api.dto.resposne.AttendeeLevelRankingResponseDto;
+import com.synergy.backend.domain.member.api.dto.resposne.AttendeePointRankingResponseDto;
+import com.synergy.backend.domain.member.entity.Attendee;
+import com.synergy.backend.domain.member.entity.RoleType;
+import com.synergy.backend.domain.member.entity.details.MembershipLevelType;
+import com.synergy.backend.module.ControllerTestSupport;
+
+class AdminControllerTest extends ControllerTestSupport {
+
+	@DisplayName("관리자가 등급별 참가자 랭킹을 조회합니다.")
+	@Test
+	@WithMockUser(username = "AD12345", roles = {"ADMIN"})
+	void getAttendeeLevelRankings() throws Exception {
+		// given
+		Attendee attendee1 = Attendee.of("email1@example.com", "encodedPassword", "참가자1", "01000000000");
+		attendee1.addTotalPoints(800);
+		Attendee attendee2 = Attendee.of("email2@example.com", "encodedPassword", "참가자2", "01011111111");
+		attendee2.addTotalPoints(10);
+
+		List<AttendeeLevelRankingResponseDto> rankingList = List.of(
+			AttendeeLevelRankingResponseDto.from(attendee1)
+		);
+		Page<AttendeeLevelRankingResponseDto> page = new PageImpl<>(rankingList, PageRequest.of(0, 10),
+			rankingList.size());
+
+		given(adminService.getAttendeeLevelRankings(any(), any())).willReturn(page);
+		given(jwtProvider.validateAccessToken(anyString())).willReturn(true);
+		given(jwtProvider.getRoleTypeFromToken(anyString())).willReturn(RoleType.ADMIN);
+		given(userDetailsService.loadUserByUsername(anyString())).willReturn(mock(UserDetails.class));
+
+		// when & then
+		mockMvc.perform(get("/api/v1/admin/attendees/level-rankings")
+				.param("membershipLevelType", MembershipLevelType.GOLD.name())
+				.param("page", "0")
+				.param("size", "10")
+				.with(csrf())
+				.contentType(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.totalElements").value(1))
+			.andExpect(jsonPath("$.data.content[0].attendeeName").value("참가자1"))
+			.andExpect(jsonPath("$.data.content[0].membershipLevel").value(MembershipLevelType.GOLD.name()))
+			.andDo(print());
+	}
+
+	@DisplayName("관리자가 포인트 랭킹을 조회합니다.")
+	@Test
+	@WithMockUser(username = "AD12345", roles = {"ADMIN"})
+	void getAttendeePointRankings() throws Exception {
+		// given
+		Attendee attendee1 = Attendee.of("email1@example.com", "encodedPassword", "참가자1", "010-0000-0000");
+		attendee1.addTotalPoints(100);
+		Attendee attendee2 = Attendee.of("email2@example.com", "encodedPassword", "참가자2", "010-1111-1111");
+		attendee2.addTotalPoints(80);
+
+		List<AttendeePointRankingResponseDto> rankingList = List.of(
+			AttendeePointRankingResponseDto.from(attendee1),
+			AttendeePointRankingResponseDto.from(attendee2)
+		);
+		Page<AttendeePointRankingResponseDto> page = new PageImpl<>(rankingList, PageRequest.of(0, 10),
+			rankingList.size());
+
+		given(adminService.getAttendeePointRankings(any())).willReturn(page);
+		given(jwtProvider.validateAccessToken(anyString())).willReturn(true);
+		given(jwtProvider.getRoleTypeFromToken(anyString())).willReturn(RoleType.ADMIN);
+		given(userDetailsService.loadUserByUsername(anyString())).willReturn(mock(UserDetails.class));
+
+		// when & then
+		mockMvc.perform(get("/api/v1/admin/attendees/point-rankings")
+				.param("page", "0")
+				.param("size", "10")
+				.with(csrf())
+				.contentType(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.totalElements").value(2))
+			.andExpect(jsonPath("$.data.content[0].attendeeName").value("참가자1"))
+			.andExpect(jsonPath("$.data.content[0].totalPoints").value(100))
+			.andDo(print());
+	}
+}

--- a/src/test/java/com/synergy/backend/domain/member/api/AttendeeControllerTest.java
+++ b/src/test/java/com/synergy/backend/domain/member/api/AttendeeControllerTest.java
@@ -1,0 +1,212 @@
+package com.synergy.backend.domain.member.api;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.synergy.backend.domain.member.api.dto.resposne.LikedRecruiterResponseDto;
+import com.synergy.backend.domain.member.api.dto.resposne.ProfileImageUpdatedResponseDto;
+import com.synergy.backend.domain.member.entity.Attendee;
+import com.synergy.backend.global.security.CustomUserDetails;
+import com.synergy.backend.module.ControllerTestSupport;
+
+@DisplayName("AttendeeController 테스트")
+class AttendeeControllerTest extends ControllerTestSupport {
+
+	@DisplayName("좋아요한 채용담당자 목록을 조회한다")
+	@Test
+	void getLikedRecruiters() throws Exception {
+		// given
+		Long attendeeId = 1L;
+		CustomUserDetails userDetails = new CustomUserDetails(createAttendee(attendeeId));
+		SecurityContextHolder.getContext().setAuthentication(
+			new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+		);
+
+		List<LikedRecruiterResponseDto> liked = List.of(
+			new LikedRecruiterResponseDto("회사1", "책임1", "홍길동"),
+			new LikedRecruiterResponseDto("회사2", "책임2", "김철수")
+		);
+
+		given(recruiterAttendeeLikeService.getLikedRecruiters(attendeeId)).willReturn(liked);
+
+		// when & then
+		mockMvc.perform(get("/api/v1/attendee/liked-recruiters")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.length()").value(2))
+			.andExpect(jsonPath("$.data[0].company").value("회사1"))
+			.andExpect(jsonPath("$.data[0].responsibility").value("책임1"))
+			.andExpect(jsonPath("$.data[0].name").value("홍길동"))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("참가자 현재 직무 정보 등록 요청을 처리한다")
+	void addJobInfo() throws Exception {
+		Long attendeeId = 1L;
+		CustomUserDetails userDetails = new CustomUserDetails(createAttendee(attendeeId));
+		SecurityContextHolder.getContext().setAuthentication(
+			new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+		);
+
+		String requestBody = """
+			{
+			    "interestCodes": [101, 102, 103],
+			    "jobGroupCode": 1,
+			    "jobPositionCode": 101,
+			    "hiringInterested": true
+			}
+			""";
+
+		mockMvc.perform(patch("/api/v1/attendee/onboarding/job-info")
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(requestBody))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value(200))
+			.andDo(print());
+
+		then(attendeeService).should().addJobInfo(eq(attendeeId), any());
+	}
+
+	@DisplayName("내 정보를 조회한다")
+	@Test
+	void getMyInformation() throws Exception {
+		Long attendeeId = 1L;
+		CustomUserDetails userDetails = new CustomUserDetails(createAttendee(attendeeId));
+		SecurityContextHolder.getContext().setAuthentication(
+			new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+		);
+
+		given(attendeeService.getMyInformation(attendeeId)).willReturn(null);
+
+		mockMvc.perform(get("/api/v1/attendee/my")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value(200))
+			.andDo(print());
+
+		then(attendeeService).should().getMyInformation(attendeeId);
+	}
+
+	@DisplayName("특정 참가자의 상세 정보를 조회한다")
+	@Test
+	void getAttendeeInfoDetail() throws Exception {
+		Long attendeeId = 1L;
+		Long targetId = 2L;
+		CustomUserDetails userDetails = new CustomUserDetails(createAttendee(attendeeId));
+		SecurityContextHolder.getContext().setAuthentication(
+			new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+		);
+
+		given(attendeeService.getAttendeeInfoDetail(targetId, attendeeId, userDetails.getRole())).willReturn(null);
+
+		mockMvc.perform(get("/api/v1/attendee/{attendeeId}", targetId)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value(200))
+			.andDo(print());
+
+		then(attendeeService).should().getAttendeeInfoDetail(targetId, attendeeId, userDetails.getRole());
+	}
+
+	@DisplayName("참가자 상세 직무 정보 등록 요청을 처리한다")
+	@Test
+	void addJobInfoDetails() throws Exception {
+		Long attendeeId = 1L;
+		CustomUserDetails userDetails = new CustomUserDetails(createAttendee(attendeeId));
+		SecurityContextHolder.getContext().setAuthentication(
+			new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+		);
+
+		MockMultipartFile request = new MockMultipartFile(
+			"request",
+			"request.json",
+			MediaType.APPLICATION_JSON_VALUE,
+			"""
+				{
+					"desiredJobGroupCode": 1,
+					"desiredJobPositionCode": 101,
+					"educationLevelCode": 3,
+					"ageGroupCode": 20,
+					"techStacks": "Java,Spring",
+					"experienceLevelCode": 2,
+					"desiredWorkRegionCodes": [11, 22],
+					"selfIntroduction": "저는 열정적인 백엔드 개발자입니다.",
+					"additionalInfo": "스타트업 인턴 경험, 외부 해커톤 참가",
+					"workplaceSelectionFactorCodes": [1, 2],
+					"preferredCorporateCultureCodes": [1],
+					"conferencePurposeCodes": [1, 2]
+				}
+				""".getBytes()
+		);
+
+		MockMultipartFile profileImage = new MockMultipartFile("profileImage", "profile.png", MediaType.IMAGE_PNG_VALUE,
+			"image content".getBytes());
+
+		mockMvc.perform(multipart("/api/v1/attendee/onboarding/job-info-details")
+				.file(request)
+				.file(profileImage)
+				.with(csrf())
+				.with(requestBuilder -> {
+					requestBuilder.setMethod("PATCH");
+					return requestBuilder;
+				})
+				.contentType(MediaType.MULTIPART_FORM_DATA))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value(200))
+			.andDo(print());
+
+		then(attendeeService).should().addJobInfoDetails(eq(attendeeId), any(), any());
+	}
+
+	@DisplayName("참가자 프로필 사진을 수정한다")
+	@Test
+	void updateProfileImage() throws Exception {
+		Long attendeeId = 1L;
+		CustomUserDetails userDetails = new CustomUserDetails(createAttendee(attendeeId));
+		SecurityContextHolder.getContext().setAuthentication(
+			new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+		);
+
+		MockMultipartFile profileImage = new MockMultipartFile("profileImage", "profile.png", MediaType.IMAGE_PNG_VALUE,
+			"image content".getBytes());
+
+		given(attendeeService.updateProfileImage(eq(attendeeId), any())).willReturn(
+			ProfileImageUpdatedResponseDto.from("updated-url"));
+
+		mockMvc.perform(multipart("/api/v1/attendee/profile-image")
+				.file(profileImage)
+				.with(csrf())
+				.with(request -> {
+					request.setMethod("PATCH");
+					return request;
+				})
+				.contentType(MediaType.MULTIPART_FORM_DATA))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value(200))
+			.andExpect(jsonPath("$.data.profileImageUrl").value("updated-url"))
+			.andDo(print());
+
+		then(attendeeService).should().updateProfileImage(eq(attendeeId), any());
+	}
+
+	private Attendee createAttendee(Long id) {
+		Attendee attendee = Attendee.of("exaple@example.com", "pass", "참가자", "01101010");
+		ReflectionTestUtils.setField(attendee, "id", id);
+		return attendee;
+	}
+}

--- a/src/test/java/com/synergy/backend/domain/member/api/RecruiterControllerTest.java
+++ b/src/test/java/com/synergy/backend/domain/member/api/RecruiterControllerTest.java
@@ -1,122 +1,246 @@
 package com.synergy.backend.domain.member.api;
 
-import com.synergy.backend.domain.member.api.dto.request.AttendeeFilterRequest;
-import com.synergy.backend.domain.member.api.dto.resposne.AttendeeListResponse;
-import com.synergy.backend.domain.member.api.dto.resposne.AttendeeSimpleResponseDto;
-import com.synergy.backend.domain.member.entity.RoleType;
-import com.synergy.backend.module.ControllerTestSupport;
+import static com.synergy.backend.domain.member.entity.details.ExperienceLevelType.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.test.context.support.WithMockUser;
 
-import java.util.List;
-
-import static com.synergy.backend.domain.member.entity.details.ExperienceLevelType.JUNIOR;
-import static com.synergy.backend.domain.member.entity.details.ExperienceLevelType.MID_LEVEL;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.mock;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.synergy.backend.domain.member.api.dto.request.AttendeeFilterRequest;
+import com.synergy.backend.domain.member.api.dto.resposne.AttendeeListResponse;
+import com.synergy.backend.domain.member.api.dto.resposne.AttendeeSimpleResponseDto;
+import com.synergy.backend.domain.member.api.dto.resposne.RecruiterMyInfoResponseDto;
+import com.synergy.backend.domain.member.entity.RoleType;
+import com.synergy.backend.domain.member.entity.User;
+import com.synergy.backend.global.security.CustomUserDetails;
+import com.synergy.backend.module.ControllerTestSupport;
 
 class RecruiterControllerTest extends ControllerTestSupport {
 
+	@DisplayName("채용담당자가 참가자 목록을 조회합니다.")
+	@Test
+	@WithMockUser(username = "RC12345", roles = {"RECRUITER"})
+	void getAttendees() throws Exception {
+		// given
+		Long recruiterId = 1L;
+		List<String> occupations = List.of("백엔드", "프론트엔드");
+		String educationLevel = "4년제 졸업";
+		String ageGroup = "20~24세 이하";
+		String experienceLevel = "1~2년 이하";
+		List<String> desiredRegions = List.of("수도권", "부산광역시");
 
-    @DisplayName("채용담당자가 참가자 목록을 조회합니다.")
-    @Test
-    @WithMockUser(username = "RC12345", roles = {"RECRUITER"})
-    void getAttendees() throws Exception {
-        // given
-        Long recruiterId = 1L;
-        List<String> occupations = List.of("백엔드", "프론트엔드");
-        String educationLevel = "4년제 졸업";
-        String ageGroup = "20~24세 이하";
-        String experienceLevel = "1~2년 이하";
-        List<String> desiredRegions = List.of("수도권", "부산광역시");
+		AttendeeFilterRequest requestCondition = AttendeeFilterRequest.of(
+			occupations, educationLevel, ageGroup, experienceLevel, desiredRegions
+		);
 
-        AttendeeFilterRequest requestCondition = AttendeeFilterRequest.of(
-                occupations, educationLevel, ageGroup, experienceLevel, desiredRegions
-        );
+		// 전부다 수도권, 부산광역시 / 4년제 졸업, 20~24세 이하 라는 가정
+		List<AttendeeSimpleResponseDto> attendeesCandidates = List.of(
+			new AttendeeSimpleResponseDto(1L, "김지원1", "백엔드 개발자", JUNIOR, "Java, Spring", null, false),
+			new AttendeeSimpleResponseDto(2L, "김지원2", "백엔드 개발자", JUNIOR, "Java, Spring", null, true),
+			new AttendeeSimpleResponseDto(3L, "김지원3", "백엔드 개발자", MID_LEVEL, "Java, Spring", null, true),
+			new AttendeeSimpleResponseDto(3L, "김지원4", "백엔드 개발자", MID_LEVEL, "Java, Spring", null, true),
+			new AttendeeSimpleResponseDto(4L, "김지원5", "백엔드 개발자", JUNIOR, "Java, Spring", null, true),
+			new AttendeeSimpleResponseDto(5L, "김지원6", "프론트엔드 개발자", JUNIOR, "React", null, true),
+			new AttendeeSimpleResponseDto(6L, "김지원7", "프론트엔드 개발자", JUNIOR, "React", null, true),
+			new AttendeeSimpleResponseDto(7L, "김지원8", "프론트엔드 개발자", JUNIOR, "React", null, true),
+			new AttendeeSimpleResponseDto(8L, "김지원9", "프론트엔드 개발자", MID_LEVEL, "React", null, true),
+			new AttendeeSimpleResponseDto(9L, "김지원10", "풀스택 개발자", JUNIOR, "All", null, true),
+			new AttendeeSimpleResponseDto(10L, "김지원11", "풀스택 개발자", JUNIOR, "All", null, true),
+			new AttendeeSimpleResponseDto(11L, "정서연12", "UI/UX 디자이너", MID_LEVEL, "Figma", null, true),
+			new AttendeeSimpleResponseDto(12L, "정서연13", "UI/UX 디자이너", JUNIOR, "Figma", null, true)
+		);
 
-        // 전부다 수도권, 부산광역시 / 4년제 졸업, 20~24세 이하 라는 가정
-        List<AttendeeSimpleResponseDto> attendeesCandidates = List.of(
-                new AttendeeSimpleResponseDto(1L, "김지원1", "백엔드 개발자", JUNIOR, "Java, Spring", null, false),
-                new AttendeeSimpleResponseDto(2L, "김지원2", "백엔드 개발자", JUNIOR, "Java, Spring", null, true),
-                new AttendeeSimpleResponseDto(3L, "김지원3", "백엔드 개발자", MID_LEVEL, "Java, Spring", null, true),
-                new AttendeeSimpleResponseDto(3L, "김지원4", "백엔드 개발자", MID_LEVEL, "Java, Spring", null, true),
-                new AttendeeSimpleResponseDto(4L, "김지원5", "백엔드 개발자", JUNIOR, "Java, Spring", null, true),
-                new AttendeeSimpleResponseDto(5L, "김지원6", "프론트엔드 개발자", JUNIOR, "React", null, true),
-                new AttendeeSimpleResponseDto(6L, "김지원7", "프론트엔드 개발자", JUNIOR, "React", null, true),
-                new AttendeeSimpleResponseDto(7L, "김지원8", "프론트엔드 개발자", JUNIOR, "React", null, true),
-                new AttendeeSimpleResponseDto(8L, "김지원9", "프론트엔드 개발자", MID_LEVEL, "React", null, true),
-                new AttendeeSimpleResponseDto(9L, "김지원10", "풀스택 개발자", JUNIOR, "All", null, true),
-                new AttendeeSimpleResponseDto(10L, "김지원11", "풀스택 개발자", JUNIOR, "All", null, true),
-                new AttendeeSimpleResponseDto(11L, "정서연12", "UI/UX 디자이너", MID_LEVEL, "Figma", null, true),
-                new AttendeeSimpleResponseDto(12L, "정서연13", "UI/UX 디자이너", JUNIOR, "Figma", null, true)
-        );
+		List<AttendeeSimpleResponseDto> attendees = List.of(
+			new AttendeeSimpleResponseDto(1L, "김지원1", "백엔드 개발자", JUNIOR, "Java, Spring", null, false),
+			new AttendeeSimpleResponseDto(2L, "김지원2", "백엔드 개발자", JUNIOR, "Java, Spring", null, true),
+			new AttendeeSimpleResponseDto(5L, "김지원5", "백엔드 개발자", JUNIOR, "Java, Spring", null, true),
+			new AttendeeSimpleResponseDto(6L, "김지원6", "프론트엔드 개발자", JUNIOR, "React", null, true),
+			new AttendeeSimpleResponseDto(7L, "김지원7", "프론트엔드 개발자", JUNIOR, "React", null, true),
+			new AttendeeSimpleResponseDto(8L, "김지원8", "프론트엔드 개발자", JUNIOR, "React", null, true)
+		);
 
-        List<AttendeeSimpleResponseDto> attendees = List.of(
-                new AttendeeSimpleResponseDto(1L, "김지원1", "백엔드 개발자", JUNIOR, "Java, Spring", null, false),
-                new AttendeeSimpleResponseDto(2L, "김지원2", "백엔드 개발자", JUNIOR, "Java, Spring", null, true),
-                new AttendeeSimpleResponseDto(5L, "김지원5", "백엔드 개발자", JUNIOR, "Java, Spring", null, true),
-                new AttendeeSimpleResponseDto(6L, "김지원6", "프론트엔드 개발자", JUNIOR, "React", null, true),
-                new AttendeeSimpleResponseDto(7L, "김지원7", "프론트엔드 개발자", JUNIOR, "React", null, true),
-                new AttendeeSimpleResponseDto(8L, "김지원8", "프론트엔드 개발자", JUNIOR, "React", null, true)
-        );
+		Page<AttendeeSimpleResponseDto> page = new PageImpl<>(attendees, PageRequest.of(0, 10), attendees.size());
+		AttendeeListResponse response = AttendeeListResponse.from(page);
 
-        Page<AttendeeSimpleResponseDto> page = new PageImpl<>(attendees, PageRequest.of(0, 10), attendees.size());
-        AttendeeListResponse response = AttendeeListResponse.from(page);
+		given(recruiterService.getAttendeesBy(any(Pageable.class), eq(recruiterId), eq(requestCondition)))
+			.willReturn(response);
+		given(jwtProvider.validateAccessToken(anyString())).willReturn(true);
+		//given(jwtProvider.getEmailOrAuthCodeFromToken(anyString())).willReturn("RC12345");
+		given(jwtProvider.getRoleTypeFromToken(anyString())).willReturn(RoleType.RECRUITER);
+		given(userDetailsService.loadUserByUsername(anyString())).willReturn(mock(UserDetails.class));
 
-        given(recruiterService.getAttendeesBy(any(Pageable.class), eq(recruiterId), eq(requestCondition)))
-                .willReturn(response);
-        given(jwtProvider.validateAccessToken(anyString())).willReturn(true);
-        //given(jwtProvider.getEmailOrAuthCodeFromToken(anyString())).willReturn("RC12345");
-        given(jwtProvider.getRoleTypeFromToken(anyString())).willReturn(RoleType.RECRUITER);
-        given(userDetailsService.loadUserByUsername(anyString())).willReturn(mock(UserDetails.class));
+		// when & then
+		mockMvc.perform(get("/api/v1/recruiter/{id}/attendees", recruiterId)
+				.with(csrf())
+				.param("occupations", occupations.get(0), occupations.get(1))
+				.param("educationLevel", educationLevel)
+				.param("ageGroup", ageGroup)
+				.param("experienceLevel", experienceLevel)
+				.param("regions", desiredRegions.get(0), desiredRegions.get(1))
+				.param("page", "0")
+				.param("size", "20")
+				.contentType(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.currentPageNumber").value(0))
+			.andExpect(jsonPath("$.data.totalElements").value(6))
+			.andExpect(jsonPath("$.data.list[0].name").value("김지원1"))
+			.andExpect(jsonPath("$.data.list[0].desiredJobPosition").value("백엔드 개발자"))
+			.andExpect(jsonPath("$.data.list[0].experienceLevel").value(JUNIOR.getDescription()))
+			.andExpect(jsonPath("$.data.list[1].name").value("김지원2"))
+			.andExpect(jsonPath("$.data.list[1].desiredJobPosition").value("백엔드 개발자"))
+			.andExpect(jsonPath("$.data.list[1].experienceLevel").value(JUNIOR.getDescription()))
+			.andExpect(jsonPath("$.data.list[2].name").value("김지원5"))
+			.andExpect(jsonPath("$.data.list[2].desiredJobPosition").value("백엔드 개발자"))
+			.andExpect(jsonPath("$.data.list[2].experienceLevel").value(JUNIOR.getDescription()))
+			.andExpect(jsonPath("$.data.list[3].name").value("김지원6"))
+			.andExpect(jsonPath("$.data.list[3].desiredJobPosition").value("프론트엔드 개발자"))
+			.andExpect(jsonPath("$.data.list[3].experienceLevel").value(JUNIOR.getDescription()))
+			.andExpect(jsonPath("$.data.list[4].name").value("김지원7"))
+			.andExpect(jsonPath("$.data.list[4].desiredJobPosition").value("프론트엔드 개발자"))
+			.andExpect(jsonPath("$.data.list[4].experienceLevel").value(JUNIOR.getDescription()))
+			.andExpect(jsonPath("$.data.list[5].name").value("김지원8"))
+			.andExpect(jsonPath("$.data.list[5].desiredJobPosition").value("프론트엔드 개발자"))
+			.andExpect(jsonPath("$.data.list[5].experienceLevel").value(JUNIOR.getDescription()))
+			.andDo(print());
+	}
 
-        // when & then
-        mockMvc.perform(get("/api/v1/recruiter/{id}/attendees", recruiterId)
-                        .with(csrf())
-                        .param("occupations", occupations.get(0), occupations.get(1))
-                        .param("educationLevel", educationLevel)
-                        .param("ageGroup", ageGroup)
-                        .param("experienceLevel", experienceLevel)
-                        .param("regions", desiredRegions.get(0), desiredRegions.get(1))
-                        .param("page", "0")
-                        .param("size", "20")
-                        .contentType(APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.currentPageNumber").value(0))
-                .andExpect(jsonPath("$.data.totalElements").value(6))
-                .andExpect(jsonPath("$.data.list[0].name").value("김지원1"))
-                .andExpect(jsonPath("$.data.list[0].desiredJobPosition").value("백엔드 개발자"))
-                .andExpect(jsonPath("$.data.list[0].experienceLevel").value(JUNIOR.getDescription()))
-                .andExpect(jsonPath("$.data.list[1].name").value("김지원2"))
-                .andExpect(jsonPath("$.data.list[1].desiredJobPosition").value("백엔드 개발자"))
-                .andExpect(jsonPath("$.data.list[1].experienceLevel").value(JUNIOR.getDescription()))
-                .andExpect(jsonPath("$.data.list[2].name").value("김지원5"))
-                .andExpect(jsonPath("$.data.list[2].desiredJobPosition").value("백엔드 개발자"))
-                .andExpect(jsonPath("$.data.list[2].experienceLevel").value(JUNIOR.getDescription()))
-                .andExpect(jsonPath("$.data.list[3].name").value("김지원6"))
-                .andExpect(jsonPath("$.data.list[3].desiredJobPosition").value("프론트엔드 개발자"))
-                .andExpect(jsonPath("$.data.list[3].experienceLevel").value(JUNIOR.getDescription()))
-                .andExpect(jsonPath("$.data.list[4].name").value("김지원7"))
-                .andExpect(jsonPath("$.data.list[4].desiredJobPosition").value("프론트엔드 개발자"))
-                .andExpect(jsonPath("$.data.list[4].experienceLevel").value(JUNIOR.getDescription()))
-                .andExpect(jsonPath("$.data.list[5].name").value("김지원8"))
-                .andExpect(jsonPath("$.data.list[5].desiredJobPosition").value("프론트엔드 개발자"))
-                .andExpect(jsonPath("$.data.list[5].experienceLevel").value(JUNIOR.getDescription()))
-                .andDo(print());
+	@Test
+	@DisplayName("채용담당자가 자신의 정보를 조회합니다.")
+	void getMyInformation() throws Exception {
+		// given
+		User user = mock(User.class);
+		given(user.getId()).willReturn(1L);
+		given(user.getIdentifier()).willReturn("RC12345");
+		given(user.getRole()).willReturn(RoleType.RECRUITER);
 
-    }
+		CustomUserDetails customUserDetails = new CustomUserDetails(user);
 
+		UsernamePasswordAuthenticationToken authentication =
+			new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		given(recruiterService.getMyInformation(1L)).willReturn(
+			new RecruiterMyInfoResponseDto(
+				"https://example.com/photo.png",
+				"홍길동",
+				"시너지",
+				"프론트엔드 채용 담당자"
+			)
+		);
+
+		// when & then
+		mockMvc.perform(get("/api/v1/recruiter/my")
+				.with(csrf())
+				.contentType(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.companyPhotoUrl").value("https://example.com/photo.png"))
+			.andExpect(jsonPath("$.data.recruiterName").value("홍길동"))
+			.andExpect(jsonPath("$.data.company").value("시너지"))
+			.andExpect(jsonPath("$.data.responsibility").value("프론트엔드 채용 담당자"))
+			.andDo(print());
+	}
+
+	@DisplayName("채용담당자가 참가자에게 좋아요를 누릅니다.")
+	@Test
+	@WithMockUser(username = "RC12345", roles = {"RECRUITER"})
+	void likeAttendee() throws Exception {
+		// given
+		Long attendeeId = 1L;
+		given(jwtProvider.validateAccessToken(anyString())).willReturn(true);
+		given(jwtProvider.getRoleTypeFromToken(anyString())).willReturn(RoleType.RECRUITER);
+
+		User user = mock(User.class);
+		given(user.getId()).willReturn(1L);
+		given(user.getIdentifier()).willReturn("RC12345");
+		given(user.getRole()).willReturn(RoleType.RECRUITER);
+
+		CustomUserDetails customUserDetails = new CustomUserDetails(user);
+		UsernamePasswordAuthenticationToken authentication =
+			new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		// when & then
+		mockMvc.perform(post("/api/v1/recruiter/attendees/{attendeeId}/like", attendeeId)
+				.with(csrf())
+				.contentType(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
+
+	@DisplayName("채용담당자가 참가자에게 좋아요를 취소합니다.")
+	@Test
+	@WithMockUser(username = "RC12345", roles = {"RECRUITER"})
+	void unlikeAttendee() throws Exception {
+		// given
+		Long attendeeId = 1L;
+		given(jwtProvider.validateAccessToken(anyString())).willReturn(true);
+		given(jwtProvider.getRoleTypeFromToken(anyString())).willReturn(RoleType.RECRUITER);
+
+		User user = mock(User.class);
+		given(user.getId()).willReturn(1L);
+		given(user.getIdentifier()).willReturn("RC12345");
+		given(user.getRole()).willReturn(RoleType.RECRUITER);
+
+		CustomUserDetails customUserDetails = new CustomUserDetails(user);
+		UsernamePasswordAuthenticationToken authentication =
+			new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		// when & then
+		mockMvc.perform(delete("/api/v1/recruiter/attendees/{attendeeId}/unlike", attendeeId)
+				.with(csrf())
+				.contentType(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
+
+	@DisplayName("채용담당자가 좋아요한 참가자 목록을 조회합니다.")
+	@Test
+	@WithMockUser(username = "RC12345", roles = {"RECRUITER"})
+	void getLikedAttendees() throws Exception {
+		// given
+		List<AttendeeSimpleResponseDto> likedAttendees = List.of(
+			new AttendeeSimpleResponseDto(1L, "참가자1", "백엔드 개발자", JUNIOR, "Java", null, true),
+			new AttendeeSimpleResponseDto(2L, "참가자2", "프론트엔드 개발자", JUNIOR, "React", null, true)
+		);
+		given(jwtProvider.validateAccessToken(anyString())).willReturn(true);
+		given(jwtProvider.getRoleTypeFromToken(anyString())).willReturn(RoleType.RECRUITER);
+
+		User user = mock(User.class);
+		given(user.getId()).willReturn(1L);
+		given(user.getIdentifier()).willReturn("RC12345");
+		given(user.getRole()).willReturn(RoleType.RECRUITER);
+
+		CustomUserDetails customUserDetails = new CustomUserDetails(user);
+		UsernamePasswordAuthenticationToken authentication =
+			new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		given(recruiterAttendeeLikeService.getLikedAttendees(anyLong())).willReturn(likedAttendees);
+
+		// when & then
+		mockMvc.perform(get("/api/v1/recruiter/me/liked-attendees")
+				.with(csrf())
+				.contentType(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data[0].name").value("참가자1"))
+			.andExpect(jsonPath("$.data[1].name").value("참가자2"))
+			.andDo(print());
+	}
 }

--- a/src/test/java/com/synergy/backend/domain/member/service/AccountLockServiceImplTest.java
+++ b/src/test/java/com/synergy/backend/domain/member/service/AccountLockServiceImplTest.java
@@ -8,10 +8,13 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
+import com.synergy.backend.domain.auth.AccountLockedEvent;
 import com.synergy.backend.domain.member.entity.Attendee;
 import com.synergy.backend.domain.member.entity.User;
 import com.synergy.backend.domain.member.repository.AttendeeRepository;
@@ -24,7 +27,7 @@ class AccountLockServiceImplTest {
 	private AttendeeRepository attendeeRepository;
 
 	@Mock
-	private MailService mailService;
+	private ApplicationEventPublisher applicationEventPublisher;
 
 	@InjectMocks
 	private AccountLockServiceImpl accountLockService;
@@ -48,6 +51,10 @@ class AccountLockServiceImplTest {
 		// then
 		assertTrue(attendee.isLocked(), "계정이 잠겨야 함");
 		verify(attendeeRepository).save(attendee);
-		verify(mailService).sendVerificationCodeToMail(email);
+
+		// ArgumentCaptor로 정확한 이벤트 객체 확인
+		ArgumentCaptor<AccountLockedEvent> captor = ArgumentCaptor.forClass(AccountLockedEvent.class);
+		verify(applicationEventPublisher).publishEvent(captor.capture());
+		assertEquals(email, captor.getValue().email());
 	}
 }

--- a/src/test/java/com/synergy/backend/domain/member/service/AccountLockServiceImplTest.java
+++ b/src/test/java/com/synergy/backend/domain/member/service/AccountLockServiceImplTest.java
@@ -1,0 +1,53 @@
+package com.synergy.backend.domain.member.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.synergy.backend.domain.member.entity.Attendee;
+import com.synergy.backend.domain.member.entity.User;
+import com.synergy.backend.domain.member.repository.AttendeeRepository;
+import com.synergy.backend.global.mail.MailService;
+
+@ExtendWith(MockitoExtension.class)
+class AccountLockServiceImplTest {
+
+	@Mock
+	private AttendeeRepository attendeeRepository;
+
+	@Mock
+	private MailService mailService;
+
+	@InjectMocks
+	private AccountLockServiceImpl accountLockService;
+
+	@DisplayName("계정이 잠김상태로 바뀐다.")
+	@Test
+	void lockUserAccount_shouldLockAndSendEmail() {
+		// given
+		Long userId = 1L;
+		String email = "test@example.com";
+		User user = mock(User.class);
+		when(user.getId()).thenReturn(userId);
+
+		Attendee attendee = Attendee.of(email, "pass", "이름", "01012345678");
+
+		when(attendeeRepository.findById(userId)).thenReturn(Optional.of(attendee));
+
+		// when
+		accountLockService.lockUserAccount(user);
+
+		// then
+		assertTrue(attendee.isLocked(), "계정이 잠겨야 함");
+		verify(attendeeRepository).save(attendee);
+		verify(mailService).sendVerificationCodeToMail(email);
+	}
+}

--- a/src/test/java/com/synergy/backend/domain/member/service/AttendeeServiceImplTest.java
+++ b/src/test/java/com/synergy/backend/domain/member/service/AttendeeServiceImplTest.java
@@ -18,7 +18,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.synergy.backend.domain.interest.entity.AttendeeInterest;
 import com.synergy.backend.domain.interest.entity.Interest;
+import com.synergy.backend.domain.interest.exception.NotFoundInterestException;
 import com.synergy.backend.domain.interest.repository.AttendeeInterestRepository;
 import com.synergy.backend.domain.interest.repository.InterestRepository;
 import com.synergy.backend.domain.job.JobGroup;
@@ -40,6 +42,7 @@ import com.synergy.backend.domain.member.exception.AccessDeniedException;
 import com.synergy.backend.domain.member.repository.AttendeeRepository;
 import com.synergy.backend.global.security.CustomUserDetails;
 import com.synergy.backend.global.util.file.dto.FileInformationDto;
+import com.synergy.backend.global.util.file.exception.EmptyImageFileException;
 import com.synergy.backend.global.util.file.util.FileS3Util;
 
 @ExtendWith(MockitoExtension.class)
@@ -210,6 +213,28 @@ class AttendeeServiceImplTest {
 		assertThrows(IllegalArgumentException.class, () -> attendeeService.addJobInfo(1L, request));
 	}
 
+	@DisplayName("유효하지 않은 관심사 코드가 포함되면 예외가 발생한다.")
+	@Test
+	void addJobInfo_invalidInterestCode_throwsException() {
+		// given
+		JobInfoRequestDto request = new JobInfoRequestDto(Set.of(1, 2, 99), 100, 200, true);
+		when(attendeeRepository.findById(1L)).thenReturn(Optional.of(attendee));
+
+		// 코드 1, 2만 존재한다고 가정 (99는 없음)
+		Interest interest1 = mock(Interest.class);
+		Interest interest2 = mock(Interest.class);
+		when(interest1.getCode()).thenReturn(1);
+		when(interest2.getCode()).thenReturn(2);
+
+		when(interestRepository.findAllByCodeIn(any()))
+			.thenReturn(List.of(interest1, interest2));
+
+		// when & then
+		assertThrows(NotFoundInterestException.class, () -> {
+			attendeeService.addJobInfo(1L, request);
+		});
+	}
+
 	@DisplayName("프로필 이미지를 업데이트한다.")
 	@Test
 	void updateProfileImage_success() {
@@ -230,4 +255,82 @@ class AttendeeServiceImplTest {
 
 	}
 
+	@DisplayName("관심사 코드가 모두 유효하면 예외 없이 통과한다.")
+	@Test
+	void addJobInfo_allValidInterestCodes_passes() {
+		// given
+		JobInfoRequestDto request = new JobInfoRequestDto(Set.of(101, 102), 1, 101, true);
+		when(attendeeRepository.findById(1L)).thenReturn(Optional.of(attendee));
+
+		Interest interest1 = mock(Interest.class);
+		Interest interest2 = mock(Interest.class);
+		lenient().when(interest1.getCode()).thenReturn(101);
+		lenient().when(interest2.getCode()).thenReturn(102);
+
+		when(interestRepository.findAllByCodeIn(Set.of(101, 102)))
+			.thenReturn(List.of(interest1, interest2));
+		when(jobGroupRepository.findByCode(1)).thenReturn(Optional.of(mock(JobGroup.class)));
+		when(jobPositionRepository.findByCode(101)).thenReturn(Optional.of(mock(JobPosition.class)));
+
+		// when
+		attendeeService.addJobInfo(1L, request);
+
+		// then
+		verify(interestRepository).findAllByCodeIn(Set.of(101, 102));
+		assertThat(attendee.getAttendeeInterests()).hasSize(2);
+	}
+
+	@DisplayName("관심사가 기존과 동일하면 업데이트하지 않는다.")
+	@Test
+	void addJobInfo_sameInterests_noChange() {
+		// given
+		JobInfoRequestDto request = new JobInfoRequestDto(Set.of(1, 2), 100, 200, true);
+		when(attendeeRepository.findById(1L)).thenReturn(Optional.of(attendee));
+
+		Interest interest1 = mock(Interest.class);
+		Interest interest2 = mock(Interest.class);
+		lenient().when(interest1.getCode()).thenReturn(1);
+		lenient().when(interest2.getCode()).thenReturn(2);
+		when(jobGroupRepository.findByCode(100)).thenReturn(Optional.of(mock(JobGroup.class)));
+		when(jobPositionRepository.findByCode(200)).thenReturn(Optional.of(mock(JobPosition.class)));
+
+		Set<Interest> sameInterests = Set.of(interest1, interest2);
+
+		// mock current interests
+		AttendeeInterest ai1 = mock(AttendeeInterest.class);
+		AttendeeInterest ai2 = mock(AttendeeInterest.class);
+		when(ai1.getInterest()).thenReturn(interest1);
+		when(ai2.getInterest()).thenReturn(interest2);
+		attendee.getAttendeeInterests().addAll(Set.of(ai1, ai2));
+
+		when(interestRepository.findAllByCodeIn(Set.of(1, 2))).thenReturn(List.of(interest1, interest2));
+
+		// when
+		attendeeService.addJobInfo(1L, request);
+
+		// then
+		verify(attendeeInterestRepository, never()).deleteAll(any());
+	}
+
+	@DisplayName("프로필 이미지가 null이면 예외가 발생한다.")
+	@Test
+	void updateProfileImage_nullFile_throwsException() {
+		// when & then
+		assertThrows(EmptyImageFileException.class, () -> {
+			attendeeService.updateProfileImage(attendee.getId(), null);
+		});
+	}
+
+	@DisplayName("프로필 이미지가 비어있으면 예외가 발생한다.")
+	@Test
+	void updateProfileImage_emptyFile_throwsException() {
+		// given
+		MultipartFile emptyFile = mock(MultipartFile.class);
+		when(emptyFile.isEmpty()).thenReturn(true);
+
+		// when & then
+		assertThrows(EmptyImageFileException.class, () -> {
+			attendeeService.updateProfileImage(attendee.getId(), emptyFile);
+		});
+	}
 }

--- a/src/test/java/com/synergy/backend/domain/member/service/AuthServiceImplTest.java
+++ b/src/test/java/com/synergy/backend/domain/member/service/AuthServiceImplTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.synergy.backend.domain.auth.LoginFailedRepository;
 import com.synergy.backend.domain.conference.entity.Conference;
 import com.synergy.backend.domain.conference.exception.InvalidTicketCodeException;
 import com.synergy.backend.domain.conference.repository.ConferenceRepository;
@@ -67,6 +68,9 @@ class AuthServiceImplTest {
 	private ConferenceRepository conferenceRepository;
 
 	@Mock
+	private LoginFailedRepository loginFailedRepository;
+
+	@Mock
 	private PasswordEncoder passwordEncoder;
 
 	@Mock
@@ -103,6 +107,7 @@ class AuthServiceImplTest {
 			requestDto.name(),
 			requestDto.phone()
 		);
+		ReflectionTestUtils.setField(mockAttendee, "isLocked", false);
 	}
 
 	@DisplayName("참가자가 회원가입을 하면 새로운 회원이 정상적으로 저장된다.")

--- a/src/test/java/com/synergy/backend/domain/member/service/AuthServiceImplTest.java
+++ b/src/test/java/com/synergy/backend/domain/member/service/AuthServiceImplTest.java
@@ -144,6 +144,31 @@ class AuthServiceImplTest {
 		assertThrows(DuplicateEmailException.class, () -> authService.registerAttendee(requestDto));
 	}
 
+	@DisplayName("회원가입 시 티켓 코드가 유효하면 참가자에 컨퍼런스가 할당된다.")
+	@Test
+	void registerAttendee_AssignsConference_WhenTicketCodeIsValid() {
+		// Given
+		Conference mockConference = mock(Conference.class);
+		when(attendeeRepository.findByEmail(requestDto.email())).thenReturn(Optional.empty());
+		when(passwordEncoder.encode(requestDto.password())).thenReturn("encodedPassword");
+		when(mailService.isVerified(requestDto.email())).thenReturn(true);
+		when(conferenceRepository.findByTicketCode(requestDto.ticketCode())).thenReturn(Optional.of(mockConference));
+		when(attendeeRepository.save(any(Attendee.class))).thenAnswer(invocation -> {
+			Attendee attendee = invocation.getArgument(0);
+			ReflectionTestUtils.setField(attendee, "id", 1L);
+			return attendee;
+		});
+
+		// When
+		SignupAttendeeResponseDto response = authService.registerAttendee(requestDto);
+
+		// Then
+		assertThat(response).isNotNull();
+		ArgumentCaptor<Attendee> captor = ArgumentCaptor.forClass(Attendee.class);
+		verify(attendeeRepository).save(captor.capture());
+		assertThat(captor.getValue().getConference()).isEqualTo(mockConference);
+	}
+
 	@DisplayName("참가자 로그인 시 이메일과 비밀번호가 일치하면 JWT 토큰이 정상적으로 생성된다.")
 	@Test
 	void loginAsAttendee_Success() {
@@ -238,7 +263,6 @@ class AuthServiceImplTest {
 		assertThat(response.tokenResponseDto().accessToken()).isEqualTo("token");
 	}
 
-
 	@DisplayName("잠긴 계정에 대해 unlockAccountIfLocked 호출 시 잠금이 해제되고 저장된다.")
 	@Test
 	void unlockAccountIfLocked_shouldUnlockAndDeleteLoginFailures() {
@@ -255,6 +279,20 @@ class AuthServiceImplTest {
 		verify(loginFailedRepository).delete(mockAttendee.getEmail());
 	}
 
+	@DisplayName("잠기지 않은 계정에 대해 unlockAccountIfLocked 호출 시 아무 일도 일어나지 않는다.")
+	@Test
+	void unlockAccountIfLocked_notLockedAccount_doesNothing() {
+		// given
+		when(attendeeRepository.findByEmail(mockAttendee.getEmail()))
+			.thenReturn(Optional.of(mockAttendee)); // 잠기지 않은 상태
+
+		// when
+		authService.unlockAccountIfLocked(mockAttendee.getEmail());
+
+		// then
+		verify(attendeeRepository, never()).save(any());
+		verify(loginFailedRepository, never()).delete(any());
+	}
 
 	@DisplayName("관리자가 올바른 인증 코드로 로그인하면 JWT 토큰이 발급된다.")
 	@Test
@@ -361,6 +399,19 @@ class AuthServiceImplTest {
 			.isInstanceOf(EmailNotVerifiedException.class);
 	}
 
+	@DisplayName("비밀번호 재설정 요청 시 이름과 전화번호가 일치하면 예외가 발생하지 않는다.")
+	@Test
+	void passwordResetRequest_Success() {
+		// Given
+		when(mailService.isVerified(requestDto.email())).thenReturn(true);
+		when(attendeeRepository.findByEmail(requestDto.email())).thenReturn(Optional.of(mockAttendee));
+
+		// When & Then
+		assertThatCode(() -> authService.passwordResetRequest(
+			requestDto.email(), requestDto.name(), requestDto.phone()))
+			.doesNotThrowAnyException();
+	}
+
 	@DisplayName("비밀번호 재설정 요청 시 이름 또는 전화번호가 일치하지 않으면 예외가 발생한다.")
 	@Test
 	void passwordResetRequest_InvalidAccountInformation_ThrowsException() {
@@ -374,6 +425,28 @@ class AuthServiceImplTest {
 
 		// When & Then
 		assertThatThrownBy(() -> authService.passwordResetRequest(requestDto.email(), wrongName, wrongPhone))
+			.isInstanceOf(InvalidAccountInformationException.class);
+	}
+
+	@DisplayName("비밀번호 재설정 요청 시 이름만 다르면 예외가 발생한다.")
+	@Test
+	void passwordResetRequest_InvalidName_ThrowsException() {
+		when(mailService.isVerified(requestDto.email())).thenReturn(true);
+		when(attendeeRepository.findByEmail(requestDto.email())).thenReturn(Optional.of(mockAttendee));
+
+		assertThatThrownBy(() -> authService.passwordResetRequest(
+			requestDto.email(), "WrongName", requestDto.phone()))
+			.isInstanceOf(InvalidAccountInformationException.class);
+	}
+
+	@DisplayName("비밀번호 재설정 요청 시 전화번호만 다르면 예외가 발생한다.")
+	@Test
+	void passwordResetRequest_InvalidPhone_ThrowsException() {
+		when(mailService.isVerified(requestDto.email())).thenReturn(true);
+		when(attendeeRepository.findByEmail(requestDto.email())).thenReturn(Optional.of(mockAttendee));
+
+		assertThatThrownBy(() -> authService.passwordResetRequest(
+			requestDto.email(), requestDto.name(), "00000000000"))
 			.isInstanceOf(InvalidAccountInformationException.class);
 	}
 

--- a/src/test/java/com/synergy/backend/domain/member/service/AuthServiceImplTest.java
+++ b/src/test/java/com/synergy/backend/domain/member/service/AuthServiceImplTest.java
@@ -27,6 +27,7 @@ import com.synergy.backend.domain.member.api.dto.resposne.SignupAttendeeResponse
 import com.synergy.backend.domain.member.entity.Admin;
 import com.synergy.backend.domain.member.entity.Attendee;
 import com.synergy.backend.domain.member.entity.Recruiter;
+import com.synergy.backend.domain.member.exception.AccountLockedException;
 import com.synergy.backend.domain.member.exception.DuplicateEmailException;
 import com.synergy.backend.domain.member.exception.InvalidAccountInformationException;
 import com.synergy.backend.domain.member.exception.InvalidAuthCodeException;
@@ -87,6 +88,9 @@ class AuthServiceImplTest {
 
 	@Mock
 	private CustomUserDetailsService userDetailsService;
+
+	@Mock
+	private AccountLockService accountLockService;
 
 	private SignupAttendeeRequestDto requestDto;
 	private Attendee mockAttendee;
@@ -180,6 +184,77 @@ class AuthServiceImplTest {
 		assertThrows(UnauthorizedException.class,
 			() -> authService.loginAsAttendee(requestDto.email(), requestDto.password()));
 	}
+
+	@DisplayName("로그인 시도 5회를 초과하면 계정이 잠기고 AccountLockedException이 발생한다.")
+	@Test
+	void loginAsAttendee_ExceedsMaxAttempts_ThrowsAccountLockedException() {
+		// given
+		when(attendeeRepository.findByEmail(requestDto.email())).thenReturn(Optional.of(mockAttendee));
+		when(passwordEncoder.matches(requestDto.password(), mockAttendee.getPassword())).thenReturn(false);
+		when(loginFailedRepository.getValues(requestDto.email())).thenReturn(null, 1, 2, 3, 4); // 시도 1~5회
+		when(loginFailedRepository.increment(requestDto.email())).thenReturn(1, 2, 3, 4, 5);
+		// 첫 4번 시도는 UnauthorizedException 발생
+		for (int i = 0; i < 4; i++) {
+			assertThatThrownBy(() -> authService.loginAsAttendee(requestDto.email(), requestDto.password()))
+				.isInstanceOf(UnauthorizedException.class);
+		}        // 5번째 시도는 AccountLockedException 발생
+		assertThatThrownBy(() -> authService.loginAsAttendee(requestDto.email(), requestDto.password()))
+			.isInstanceOf(AccountLockedException.class);
+
+		// verify that lockUserAccount is called after 5th failure
+		verify(accountLockService).lockUserAccount(mockAttendee);
+		verify(loginFailedRepository).delete(requestDto.email());
+	}
+
+	@DisplayName("계정이 잠긴 참가자가 로그인하면 AccountLockedException이 발생한다.")
+	@Test
+	void loginAsAttendee_AccountLocked_ThrowsException() {
+		// given
+		mockAttendee.lockAccount(); // 계정 잠금
+		when(attendeeRepository.findByEmail(requestDto.email())).thenReturn(Optional.of(mockAttendee));
+		when(loginFailedRepository.exists(requestDto.email())).thenReturn(true); // Redis TTL이 남아있는 상태
+
+		// when & then
+		assertThatThrownBy(() -> authService.loginAsAttendee(requestDto.email(), requestDto.password()))
+			.isInstanceOf(AccountLockedException.class);
+	}
+
+	@DisplayName("TTL이 만료되어 로그인 실패 기록이 없으면 계정이 자동으로 잠금 해제된다.")
+	@Test
+	void loginAsAttendee_ExpiredTTL_UnlocksAccount() {
+		// given
+		mockAttendee.lockAccount(); // DB상으로는 잠김 상태
+		when(attendeeRepository.findByEmail(requestDto.email())).thenReturn(Optional.of(mockAttendee));
+		when(loginFailedRepository.exists(requestDto.email())).thenReturn(false); // Redis 키 만료
+		when(passwordEncoder.matches(requestDto.password(), mockAttendee.getPassword())).thenReturn(true);
+		when(jwtProvider.generateAccessToken(any())).thenReturn("token");
+
+		// when
+		TokenWithRefreshToken response = authService.loginAsAttendee(requestDto.email(), requestDto.password());
+
+		// then
+		assertFalse(mockAttendee.isLocked()); // 잠금 해제되었는지 확인
+		verify(attendeeRepository).save(mockAttendee); // DB 저장 확인
+		assertThat(response.tokenResponseDto().accessToken()).isEqualTo("token");
+	}
+
+
+	@DisplayName("잠긴 계정에 대해 unlockAccountIfLocked 호출 시 잠금이 해제되고 저장된다.")
+	@Test
+	void unlockAccountIfLocked_shouldUnlockAndDeleteLoginFailures() {
+		// given
+		mockAttendee.lockAccount(); // 잠긴 상태
+		when(attendeeRepository.findByEmail(mockAttendee.getEmail())).thenReturn(Optional.of(mockAttendee));
+
+		// when
+		authService.unlockAccountIfLocked(mockAttendee.getEmail());
+
+		// then
+		assertFalse(mockAttendee.isLocked(), "계정 잠금이 해제되어야 함");
+		verify(attendeeRepository).save(mockAttendee);
+		verify(loginFailedRepository).delete(mockAttendee.getEmail());
+	}
+
 
 	@DisplayName("관리자가 올바른 인증 코드로 로그인하면 JWT 토큰이 발급된다.")
 	@Test

--- a/src/test/java/com/synergy/backend/domain/member/service/RecruiterAttendeeLikeServiceImplTest.java
+++ b/src/test/java/com/synergy/backend/domain/member/service/RecruiterAttendeeLikeServiceImplTest.java
@@ -21,6 +21,7 @@ import com.synergy.backend.domain.member.entity.Attendee;
 import com.synergy.backend.domain.member.entity.Recruiter;
 import com.synergy.backend.domain.member.entity.RecruiterAttendeeLike;
 import com.synergy.backend.domain.member.exception.DuplicateLikeException;
+import com.synergy.backend.domain.member.exception.NotFoundLikeException;
 import com.synergy.backend.domain.member.repository.AttendeeRepository;
 import com.synergy.backend.domain.member.repository.RecruiterAttendeeLikeRepository;
 import com.synergy.backend.domain.member.repository.RecruiterRepository;
@@ -44,8 +45,9 @@ class RecruiterAttendeeLikeServiceImplTest {
 	private Recruiter recruiter2;
 	private Attendee attendee1;
 	private Attendee attendee2;
-	private RecruiterAttendeeLike like1;
-	private RecruiterAttendeeLike like2;
+	private RecruiterAttendeeLike like11;
+	private RecruiterAttendeeLike like12;
+	private RecruiterAttendeeLike like21;
 
 	@BeforeEach
 	void setUp() {
@@ -58,8 +60,9 @@ class RecruiterAttendeeLikeServiceImplTest {
 		ReflectionTestUtils.setField(attendee1, "id", 1L);
 		ReflectionTestUtils.setField(attendee2, "id", 2L);
 
-		like1 = RecruiterAttendeeLike.of(recruiter1, attendee1);
-		like2 = RecruiterAttendeeLike.of(recruiter2, attendee2);
+		like11 = RecruiterAttendeeLike.of(recruiter1, attendee1);
+		like12 = RecruiterAttendeeLike.of(recruiter1, attendee2);
+		like21 = RecruiterAttendeeLike.of(recruiter2, attendee1);
 	}
 
 	@DisplayName("채용담당자가 참가자 좋아요를 한다.")
@@ -113,23 +116,23 @@ class RecruiterAttendeeLikeServiceImplTest {
 		// given
 		Long recruiterId = 1L;
 		when(recruiterAttendeeLikeRepository.findAllByRecruiterId(recruiterId))
-			.thenReturn(List.of(like1));
+			.thenReturn(List.of(like11, like12));
 
 		// when
 		List<AttendeeSimpleResponseDto> response = recruiterAttendeeLikeService.getLikedAttendees(recruiterId);
 
 		// then
-		assertThat(response).hasSize(1);
+		assertThat(response).hasSize(2);
 		assertThat(response.get(0).getName()).isEqualTo(attendee1.getName());
 	}
 
-	@DisplayName("참가자가 좋아요한 채용 담당자 목록을 조회한다.")
+	@DisplayName("참가자가 본인을 좋아요한 채용 담당자 목록을 조회한다.")
 	@Test
 	void getLikedRecruiters() {
 		// given
 		Long attendeeId = 10L;
 		when(recruiterAttendeeLikeRepository.findAllByAttendeeId(attendeeId))
-			.thenReturn(List.of(like1, like2));
+			.thenReturn(List.of(like11, like21));
 
 		// when
 		List<LikedRecruiterResponseDto> response = recruiterAttendeeLikeService.getLikedRecruiters(attendeeId);
@@ -139,4 +142,16 @@ class RecruiterAttendeeLikeServiceImplTest {
 		assertThat(response.get(0).name()).isEqualTo(recruiter1.getName());
 		assertThat(response.get(1).name()).isEqualTo(recruiter2.getName());
 	}
+
+	@DisplayName("존재하지 않는 좋아요를 취소하려 하면 예외가 발생한다.")
+	@Test
+	void unlikeAttendee_NotFoundLike_ThrowsException() {
+		// given
+		when(recruiterAttendeeLikeRepository.existsLike(1L, 1L)).thenReturn(false);
+
+		// when & then
+		assertThatThrownBy(() -> recruiterAttendeeLikeService.unlikeAttendee(1L, 1L))
+			.isInstanceOf(NotFoundLikeException.class);
+	}
+
 }

--- a/src/test/java/com/synergy/backend/domain/point/api/PointControllerTest.java
+++ b/src/test/java/com/synergy/backend/domain/point/api/PointControllerTest.java
@@ -1,0 +1,70 @@
+package com.synergy.backend.domain.point.api;
+
+import static com.synergy.backend.domain.point.entity.PointType.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import com.synergy.backend.domain.member.entity.Attendee;
+import com.synergy.backend.domain.point.api.dto.PointResponseDto;
+import com.synergy.backend.domain.point.entity.Point;
+import com.synergy.backend.domain.point.entity.PointType;
+import com.synergy.backend.global.security.CustomUserDetails;
+import com.synergy.backend.module.ControllerTestSupport;
+
+class PointControllerTest extends ControllerTestSupport {
+
+	@DisplayName("참가자의 포인트 내역을 조회한다.")
+	@Test
+	@WithMockUser(roles = {"ATTENDEE"})
+	void getMyPoints() throws Exception {
+		// given
+		Long attendeeId = 1L;
+		CustomUserDetails userDetails = new CustomUserDetails(createAttendee(attendeeId));
+		SecurityContextHolder.getContext().setAuthentication(
+			new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+		);
+
+		List<PointResponseDto> mockResponse = List.of(
+			PointResponseDto.from(Point.of(SIGN_UP), "회원가입"),
+			PointResponseDto.from(Point.of(PointType.SESSION_ATTEND), "세션참여")
+		);
+		given(pointService.getPointResponses(Mockito.anyLong()))
+			.willReturn(mockResponse);
+
+		// when & then
+		mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/points/my-points")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value("success"))
+			.andExpect(jsonPath("$.code").value(200))
+			.andExpect(jsonPath("$.data").isArray())
+			.andExpect(jsonPath("$.data").isArray())
+			.andExpect(jsonPath("$.data[0].title").value(SIGN_UP.getMessage()))
+			.andExpect(jsonPath("$.data[0].point").value(SIGN_UP.getPointValue()))
+			.andExpect(jsonPath("$.data[0].details").value("회원가입"))
+			.andExpect(jsonPath("$.data[1].title").value(SESSION_ATTEND.getMessage()))
+			.andExpect(jsonPath("$.data[1].point").value(SESSION_ATTEND.getPointValue()))
+			.andExpect(jsonPath("$.data[1].details").value("세션참여"))
+			.andDo(print());
+
+	}
+
+	private Attendee createAttendee(Long id) {
+		Attendee attendee = Attendee.of("exaple@example.com", "pass", "참가자", "01101010");
+		ReflectionTestUtils.setField(attendee, "id", id);
+		return attendee;
+	}
+}

--- a/src/test/java/com/synergy/backend/domain/point/service/PointServiceImplTest.java
+++ b/src/test/java/com/synergy/backend/domain/point/service/PointServiceImplTest.java
@@ -14,13 +14,17 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.synergy.backend.domain.booth.entity.Booth;
 import com.synergy.backend.domain.booth.repository.BoothRepository;
 import com.synergy.backend.domain.member.entity.Attendee;
+import com.synergy.backend.domain.member.entity.Recruiter;
 import com.synergy.backend.domain.member.repository.AttendeeRepository;
 import com.synergy.backend.domain.member.repository.RecruiterRepository;
+import com.synergy.backend.domain.point.api.dto.PointResponseDto;
 import com.synergy.backend.domain.point.entity.Point;
 import com.synergy.backend.domain.point.entity.PointType;
 import com.synergy.backend.domain.point.repository.PointRepository;
+import com.synergy.backend.domain.session.entity.Session;
 import com.synergy.backend.domain.session.repository.sessionRepository.SessionRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -130,6 +134,122 @@ class PointServiceImplTest {
 		verify(attendeeRepository, times(1)).save(testAttendee);
 		assertEquals(1, testAttendee.getPoints().size());
 		assertEquals(PointType.SIGN_UP, testAttendee.getPoints().get(0).getPointType());
+	}
+
+	@DisplayName("포인트 ID로 포인트 응답을 조회할 수 있다.")
+	@Test
+	void testGetPointResponse() {
+		// given
+		when(pointRepository.findById(1L)).thenReturn(Optional.of(testPoint));
+
+		// when
+		PointResponseDto response = pointService.getPointResponse(1L);
+
+		// then
+		assertNotNull(response);
+		assertEquals(testPoint.getPointType().getMessage(), response.title());
+	}
+
+	@DisplayName("사용자의 포인트 응답 리스트를 조회할 수 있다.")
+	@Test
+	void testGetPointResponses() {
+		// given
+		when(pointRepository.findByAttendeeIdOrderByCreatedTimeDesc(1L)).thenReturn(List.of(testPoint));
+		when(pointRepository.findById(any())).thenReturn(Optional.of(testPoint));
+
+		// when
+		List<PointResponseDto> responses = pointService.getPointResponses(1L);
+
+		// then
+		assertEquals(1, responses.size());
+		assertEquals(testPoint.getPointType().getMessage(), responses.get(0).title());
+	}
+
+	@DisplayName("포인트 타입이 부스참여인 경우 포인트 상세정보로 부스 회사명을 반환한다.")
+	@Test
+	void testGetDetailsForPoint() {
+		// given
+		Point boothPoint = Point.builder().pointType(PointType.BOOTH_VISIT).boothId(10L).build();
+		Booth booth = mock(Booth.class);
+		when(booth.getCompanyName()).thenReturn("테스트회사");
+		when(boothRepository.findById(10L)).thenReturn(Optional.of(booth));
+
+		// when
+		String result = pointService.getDetailsForPoint(boothPoint);
+
+		// then
+		assertEquals("테스트회사", result);
+	}
+
+	@DisplayName("포인트 타입이 세션참여 또는 QnA인 경우 포인트 상세정보로 세션 제목을 반환한다.")
+	@Test
+	void testGetDetailsForPoint_SessionTypes() {
+		// given
+		Point sessionPoint = Point.builder().pointType(PointType.SESSION_ATTEND).sessionId(20L).build();
+		Session session = mock(Session.class);
+		when(session.getTitle()).thenReturn("세션 제목");
+		when(sessionRepository.findById(20L)).thenReturn(Optional.of(session));
+
+		// when
+		String result = pointService.getDetailsForPoint(sessionPoint);
+
+		// then
+		assertEquals("세션 제목", result);
+	}
+
+	@DisplayName("포인트 타입이 채용담당자 미팅인 경우 채용담당자 회사명을 반환한다.")
+	@Test
+	void testGetDetailsForPoint_RecruiterMeeting() {
+		// given
+		Point point = Point.builder().pointType(PointType.RECRUITER_MEETING).recruiterId(30L).build();
+		Recruiter recruiter = mock(Recruiter.class);
+		when(recruiter.getCompany()).thenReturn("채용담당자회사");
+		when(recruiterRepository.findById(30L)).thenReturn(Optional.of(recruiter));
+
+		// when
+		String result = pointService.getDetailsForPoint(point);
+
+		// then
+		assertEquals("채용담당자회사", result);
+	}
+
+	@DisplayName("포인트 타입이 회원가입인 경우 정해진 메시지를 반환한다.")
+	@Test
+	void testGetDetailsForPoint_SignUp() {
+		// given
+		Point point = Point.builder().pointType(PointType.SIGN_UP).build();
+
+		// when
+		String result = pointService.getDetailsForPoint(point);
+
+		// then
+		assertEquals("회원가입 적립", result);
+	}
+
+	@DisplayName("포인트 타입이 설문조사 참여인 경우 정해진 메시지를 반환한다.")
+	@Test
+	void testGetDetailsForPoint_SurveyParticipation() {
+		// given
+		Point point = Point.builder().pointType(PointType.SURVEY_PARTICIPATION).build();
+
+		// when
+		String result = pointService.getDetailsForPoint(point);
+
+		// then
+		assertEquals("설문조사 참여 적립", result);
+	}
+
+	@DisplayName("포인트 타입이 컨텐츠 공유인 경우 정해진 메시지를 반환한다.")
+	@Test
+	void testGetDetailsForPoint_ContentShare() {
+		// given
+		Point point = Point.builder().pointType(PointType.CONTENT_SHARE).build();
+
+		// when
+		String result = pointService.getDetailsForPoint(point);
+
+		// then
+		assertEquals("컨텐츠 공유 적립", result);
 	}
 
 }

--- a/src/test/java/com/synergy/backend/global/security/JwtProviderTest.java
+++ b/src/test/java/com/synergy/backend/global/security/JwtProviderTest.java
@@ -20,6 +20,10 @@ import com.synergy.backend.domain.member.entity.RoleType;
 import com.synergy.backend.global.jwt.JwtProperties;
 import com.synergy.backend.global.jwt.JwtProvider;
 import com.synergy.backend.global.token.exception.InvalidAccessTokenException;
+import com.synergy.backend.global.token.exception.InvalidRefreshTokenException;
+import com.synergy.backend.global.token.exception.MissingRoleClaimException;
+import com.synergy.backend.global.token.exception.InvalidRoleClaimException;
+import com.synergy.backend.global.token.exception.ExpiredRefreshTokenException;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -38,6 +42,21 @@ class JwtProviderTest {
 		lenient().when(jwtProperties.accessTokenExpiration()).thenReturn(Duration.ofMinutes(30));
 		lenient().when(jwtProperties.refreshTokenExpiration()).thenReturn(Duration.ofDays(30));
 		jwtProvider = new JwtProvider(jwtProperties);
+	}
+
+	@Test
+	@DisplayName("AccessToken이 유효하면 true를 반환한다.")
+	void validateAccessToken_ValidToken_ReturnsTrue() {
+		// given
+		Attendee attendee = Attendee.of("attendee@example.com", "hashedPassword", "user", "phone");
+		CustomUserDetails userDetails = new CustomUserDetails(attendee);
+		String accessToken = jwtProvider.generateAccessToken(userDetails);
+
+		// when
+		boolean isValid = jwtProvider.validateAccessToken(accessToken);
+
+		// then
+		assertTrue(isValid);
 	}
 
 	@Test
@@ -138,5 +157,112 @@ class JwtProviderTest {
 
 		// When & Then
 		assertThrows(InvalidAccessTokenException.class, () -> jwtProvider.validateAccessToken(refreshToken));
+	}
+
+	@Test
+	@DisplayName("RefreshToken이 유효하면 true를 반환한다.")
+	void validateRefreshToken_ValidToken_ReturnsTrue() {
+		// given
+		Attendee attendee = Attendee.of("attendee@example.com", "hashedPassword", "user", "phone");
+		CustomUserDetails userDetails = new CustomUserDetails(attendee);
+		String refreshToken = jwtProvider.generateRefreshToken(userDetails);
+
+		// when
+		boolean isValid = jwtProvider.validateRefreshToken(refreshToken);
+
+		// then
+		assertTrue(isValid);
+	}
+
+	@Test
+	@DisplayName("AccessToken으로 RefreshToken 검증 시 InvalidRefreshTokenException 발생")
+	void validateRefreshToken_UsingAccessToken_ThrowsException() {
+		// given
+		Attendee attendee = Attendee.of("attendee@example.com", "hashedPassword", "user", "phone");
+		CustomUserDetails userDetails = new CustomUserDetails(attendee);
+		String accessToken = jwtProvider.generateAccessToken(userDetails);
+
+		// when & then
+		assertThrows(InvalidRefreshTokenException.class, () -> jwtProvider.validateRefreshToken(accessToken));
+	}
+
+	@Test
+	@DisplayName("유효하지 않은 RefreshToken은 InvalidRefreshTokenException을 발생시킨다.")
+	void validateRefreshToken_InvalidToken_ThrowsException() {
+		// given
+		String invalidToken = "invalid.refresh.token";
+
+		// when & then
+		assertThrows(InvalidRefreshTokenException.class, () -> jwtProvider.validateRefreshToken(invalidToken));
+	}
+
+	@Test
+	@DisplayName("만료된 RefreshToken은 ExpiredRefreshTokenException을 발생시킨다.")
+	void validateRefreshToken_Expired_ThrowsException() {
+		// given
+		Attendee attendee = Attendee.of("attendee@example.com", "hashedPassword", "user", "phone");
+		CustomUserDetails userDetails = new CustomUserDetails(attendee);
+		String expiredToken = Jwts.builder()
+			.setSubject(userDetails.getIdentifier())
+			.claim("id", userDetails.getId())
+			.claim("role", userDetails.getRole().getAuthority())
+			.claim("type", "refresh")
+			.setIssuedAt(new Date(System.currentTimeMillis() - 60000))
+			.setExpiration(new Date(System.currentTimeMillis() - 1000))
+			.signWith(Keys.hmacShaKeyFor("your-secret-key-which-is-at-least-32-bytes-long!!!".getBytes()), SignatureAlgorithm.HS256)
+			.compact();
+
+		// when & then
+		assertThrows(ExpiredRefreshTokenException.class, () -> jwtProvider.validateRefreshToken(expiredToken));
+	}
+
+	@Test
+	@DisplayName("토큰에서 id를 추출할 수 있다.")
+	void getIdFromToken_ReturnsId() {
+		// given
+		Attendee attendee = Attendee.of("attendee@example.com", "hashedPassword", "user", "phone");
+		CustomUserDetails userDetails = new CustomUserDetails(attendee);
+		String token = jwtProvider.generateAccessToken(userDetails);
+
+		// when
+		Long id = jwtProvider.getIdFromToken(token);
+
+		// then
+		assertEquals(userDetails.getId(), id);
+	}
+
+	@Test
+	@DisplayName("role claim이 없으면 MissingRoleClaimException이 발생한다.")
+	void getRoleTypeFromToken_MissingRole_ThrowsException() {
+		// given
+		String token = Jwts.builder()
+			.setSubject("subject")
+			.claim("id", 1L)
+			.claim("type", "access")
+			.setIssuedAt(new Date())
+			.setExpiration(new Date(System.currentTimeMillis() + 60000))
+			.signWith(Keys.hmacShaKeyFor("your-secret-key-which-is-at-least-32-bytes-long!!!".getBytes()), SignatureAlgorithm.HS256)
+			.compact();
+
+		// when & then
+		assertThrows(MissingRoleClaimException.class, () -> jwtProvider.getRoleTypeFromToken(token));
+	}
+
+	@Test
+	@DisplayName("잘못된 role claim이면 InvalidRoleClaimException이 발생한다.")
+	void getRoleTypeFromToken_InvalidRole_ThrowsException() {
+		// given
+		String token = Jwts.builder()
+			.setSubject("subject")
+			.claim("id", 1L)
+			.claim("role", "INVALID_ROLE")
+			.claim("type", "access")
+			.setIssuedAt(new Date())
+			.setExpiration(new Date(System.currentTimeMillis() + 60000))
+			.signWith(Keys.hmacShaKeyFor("your-secret-key-which-is-at-least-32-bytes-long!!!".getBytes()), SignatureAlgorithm.HS256)
+			.compact();
+
+		// when & then
+		assertThrows(InvalidRoleClaimException.class, () -> jwtProvider.getRoleTypeFromToken(token));
 	}
 }

--- a/src/test/java/com/synergy/backend/module/ControllerTestSupport.java
+++ b/src/test/java/com/synergy/backend/module/ControllerTestSupport.java
@@ -13,15 +13,22 @@ import com.synergy.backend.domain.booth.service.BoothService;
 import com.synergy.backend.domain.conference.api.ConferenceController;
 import com.synergy.backend.domain.conference.service.ConferenceService;
 import com.synergy.backend.domain.member.api.AdminController;
+import com.synergy.backend.domain.member.api.AttendeeController;
 import com.synergy.backend.domain.member.api.RecruiterController;
 import com.synergy.backend.domain.member.service.AdminService;
+import com.synergy.backend.domain.member.service.AttendeeService;
 import com.synergy.backend.domain.member.service.RecruiterAttendeeLikeService;
 import com.synergy.backend.domain.member.service.RecruiterService;
 import com.synergy.backend.global.jwt.JwtProvider;
 import com.synergy.backend.global.security.CustomUserDetailsService;
 
-@WebMvcTest(controllers = {BoothController.class, ConferenceController.class, RecruiterController.class,
-	AdminController.class} /* 추가로 필요한 컨트롤러 클래스 지정 */)
+@WebMvcTest(controllers = {
+	BoothController.class,
+	ConferenceController.class,
+	RecruiterController.class,
+	AdminController.class,
+	AttendeeController.class
+} /* 추가로 필요한 컨트롤러 클래스 지정 */)
 public abstract class ControllerTestSupport {
 	protected final ObjectMapper objectMapper = new ObjectMapper()
 		.registerModule(new JavaTimeModule())
@@ -42,4 +49,6 @@ public abstract class ControllerTestSupport {
 	protected CustomUserDetailsService userDetailsService;
 	@MockitoBean
 	protected AdminService adminService;
+	@MockitoBean
+	protected AttendeeService attendeeService;
 }

--- a/src/test/java/com/synergy/backend/module/ControllerTestSupport.java
+++ b/src/test/java/com/synergy/backend/module/ControllerTestSupport.java
@@ -19,6 +19,8 @@ import com.synergy.backend.domain.member.service.AdminService;
 import com.synergy.backend.domain.member.service.AttendeeService;
 import com.synergy.backend.domain.member.service.RecruiterAttendeeLikeService;
 import com.synergy.backend.domain.member.service.RecruiterService;
+import com.synergy.backend.domain.point.api.PointController;
+import com.synergy.backend.domain.point.service.PointService;
 import com.synergy.backend.global.jwt.JwtProvider;
 import com.synergy.backend.global.security.CustomUserDetailsService;
 
@@ -27,7 +29,8 @@ import com.synergy.backend.global.security.CustomUserDetailsService;
 	ConferenceController.class,
 	RecruiterController.class,
 	AdminController.class,
-	AttendeeController.class
+	AttendeeController.class,
+	PointController.class
 } /* 추가로 필요한 컨트롤러 클래스 지정 */)
 public abstract class ControllerTestSupport {
 	protected final ObjectMapper objectMapper = new ObjectMapper()
@@ -51,4 +54,6 @@ public abstract class ControllerTestSupport {
 	protected AdminService adminService;
 	@MockitoBean
 	protected AttendeeService attendeeService;
+	@MockitoBean
+	protected PointService pointService;
 }

--- a/src/test/java/com/synergy/backend/module/ControllerTestSupport.java
+++ b/src/test/java/com/synergy/backend/module/ControllerTestSupport.java
@@ -1,5 +1,10 @@
 package com.synergy.backend.module;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -7,40 +12,34 @@ import com.synergy.backend.domain.booth.controller.BoothController;
 import com.synergy.backend.domain.booth.service.BoothService;
 import com.synergy.backend.domain.conference.api.ConferenceController;
 import com.synergy.backend.domain.conference.service.ConferenceService;
+import com.synergy.backend.domain.member.api.AdminController;
 import com.synergy.backend.domain.member.api.RecruiterController;
+import com.synergy.backend.domain.member.service.AdminService;
 import com.synergy.backend.domain.member.service.RecruiterAttendeeLikeService;
 import com.synergy.backend.domain.member.service.RecruiterService;
 import com.synergy.backend.global.jwt.JwtProvider;
 import com.synergy.backend.global.security.CustomUserDetailsService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(controllers = {BoothController.class, ConferenceController.class, RecruiterController.class} /* 추가로 필요한 컨트롤러 클래스 지정 */)
+@WebMvcTest(controllers = {BoothController.class, ConferenceController.class, RecruiterController.class,
+	AdminController.class} /* 추가로 필요한 컨트롤러 클래스 지정 */)
 public abstract class ControllerTestSupport {
-    @Autowired
-    protected MockMvc mockMvc;
-
-    @MockitoBean
-    protected BoothService boothService;
-    @MockitoBean
-    protected ConferenceService conferenceService;
-    @MockitoBean
-    protected RecruiterService recruiterService;
-
-    @MockitoBean
-    protected RecruiterAttendeeLikeService recruiterAttendeeLikeService;
-
-
-    @MockitoBean
-    protected JwtProvider jwtProvider;
-    @MockitoBean
-    protected CustomUserDetailsService userDetailsService;
-
-
-    protected final ObjectMapper objectMapper = new ObjectMapper()
-            .registerModule(new JavaTimeModule())
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+	protected final ObjectMapper objectMapper = new ObjectMapper()
+		.registerModule(new JavaTimeModule())
+		.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+	@Autowired
+	protected MockMvc mockMvc;
+	@MockitoBean
+	protected BoothService boothService;
+	@MockitoBean
+	protected ConferenceService conferenceService;
+	@MockitoBean
+	protected RecruiterService recruiterService;
+	@MockitoBean
+	protected RecruiterAttendeeLikeService recruiterAttendeeLikeService;
+	@MockitoBean
+	protected JwtProvider jwtProvider;
+	@MockitoBean
+	protected CustomUserDetailsService userDetailsService;
+	@MockitoBean
+	protected AdminService adminService;
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 진행한 이슈
- close #108

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 진행 사항
이슈를 해결하기 위해 진행했던 사항들을 구체적으로 알려주세요.

### 참가자 로그인 횟수 제한 기능 추가
잘못된 비밀번호로 로그인 시도가 일정 횟수를 초과할 경우,
계정을 잠그고 이메일 인증을 통해서만 해제할 수 있도록 하는 보안 로직 강화를 목적으로 합니다.

로그인 재시도 횟수는 Redis로 관리되며, 일정 시간(TTL)이 지나면 자동 초기화됩니다. (현재 30분으로 설정)

![LoginAttemptAccountLock-___________](https://github.com/user-attachments/assets/d6d321d5-411d-4c2c-9fd2-50304a9835e3)


1. 로그인 실패 시도 제한 기능 추가
- 로그인 실패 시마다 Redis에 카운트를 저장 (LoginFailedRepository)
- MAX_ATTEMPT_COUNT 이상 실패 시 계정 잠금
- 잠금 상태는 DB(Attendee.isLocked)에 저장됨
- TTL(30분)이 지난 후 Redis 값이 삭제되면 자동 잠금 해제 가능

2. 계정 잠금 시 이메일 인증 코드 발송
- AccountLockServiceImpl에서 계정 잠금 처리 후 이벤트(AccountLockedEvent) 발행
- AccountLockedEventHandler가 해당 이벤트를 수신하여 MailService를 통해 메일 전송

3. 계정 잠김 시 로그인 차단 처리
- 로그인 시 isLocked == true && Redis에 실패 기록이 남아있다면 로그인 차단
- 실패 기록이 없으면 (TTL 만료) → 계정 자동 해제 처리

4. 이메일 인증 후 잠금 해제
- /auth/email/verification/confirm 엔드포인트에서 인증 코드 확인 후
- 인증 목적이 UNLOCK_ACCOUNT일 경우 unlockAccountIfLocked() 실행


**Propagation.REQUIRES_NEW를 사용한 이유**
- 계정 잠금 처리는 로그인 시도 로직 중 하나로 실행됩니다.
- 이때 로그인 전체 트랜잭션이 실패하더라도 계정 잠금은 반드시 저장되어야 하기 때문에,
- @Transactional(propagation = REQUIRES_NEW)를 사용하여 별도의 트랜잭션으로 분리했습니다.

- 이로 인해 기존 트랜잭션에서 전달된 사용자 객체(User)는 새로운 트랜잭션에서는 detached 상태가 되어 영속성 컨텍스트에서 관리되지 않습니다.
- 따라서 DB에서 다시 조회(findBy)하여 영속 상태로 만들고, isLocked = true 상태를 명시적으로 저장(save())하여 새로운 트랜잭션에서 반영되도록 처리했습니다.


**AccountLockedEvent를 도입한 이유**
- 처음에는 계정 잠금 처리와 동시에 MailService를 직접 호출하여 인증 메일을 전송했지만,
메일 전송은 외부 SMTP 서버와의 통신이 필요한 작업으로,
트랜잭션 내부에서 호출 시 실패해도 롤백되지 않으며,
실패 시 계정은 잠겼는데 메일은 발송되지 않는 불일치 상황이 발생할 수 있었습니다.
- 이를 해결하기 위해 AccountLockedEvent를 도입하여 도메인 이벤트 발행 → 이벤트 리스너에서 메일 전송 구조로 개선하였습니다.



### 테스트 코드 추가
Service 코드 중 분기점 등 기타 테스트 안되어있는 부분 추가하였습니다.