### PR TITLE
fix: 부스 순위 조회 시 0인 값에 대해서 반환하지 않도록 수정

### DIFF
--- a/src/main/java/com/synergy/backend/domain/booth/repository/querydsl/BoothRepositoryImpl.java
+++ b/src/main/java/com/synergy/backend/domain/booth/repository/querydsl/BoothRepositoryImpl.java
@@ -46,6 +46,7 @@ public class BoothRepositoryImpl implements BoothRepositoryCustom {
                         booth.progressDate.eq(currentDate)
                 )
                 .groupBy(booth.id)
+                .having(boothParticipation.count().ne(0L))
                 .orderBy(boothParticipation.count().desc())
                 .limit(3)
                 .fetch();


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 진행한 이슈
- close #이슈번호

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 진행 사항
이슈를 해결하기 위해 진행했던 사항들을 구체적으로 알려주세요.

부스 조회 시 참여자가 0인 부스에 대해 리스트업을 하지 않도록 수정했습니다.