### PR TITLE
Feat : 부스, 세션 대시보드 수정

### DIFF
--- a/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/BoothDtoMapper.java
+++ b/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/BoothDtoMapper.java
@@ -1,0 +1,23 @@
+package com.synergy.backend.domain.booth.dto.boothParticipateDto;
+
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.collection.BoothParticipateInterestedTechDtoList;
+
+public class BoothDtoMapper {
+
+    public static BoothParticipationInterestedResponseDto withProcessedTechs(
+            BoothParticipationInterestedResponseDto original,
+            BoothParticipateInterestedTechDtoList processed
+    ) {
+        return new BoothParticipationInterestedResponseDto(
+                original.getBoothId(),
+                original.getCompanyName(),
+                original.getCompanyType(),
+                original.getBoothLocation(),
+                original.getBoothNumber(),
+                original.getBoothDescription(),
+                original.getProgressDate(),
+                original.getQrCode(),
+                processed.getValues()
+        );
+    }
+}

--- a/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/BoothParticipationInterestedResponseDto.java
+++ b/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/BoothParticipationInterestedResponseDto.java
@@ -35,6 +35,19 @@ public class BoothParticipationInterestedResponseDto {
 		this.dataset = new ArrayList<>();
 	}
 
+	public BoothParticipationInterestedResponseDto(Long boothId, String companyName, String companyType, String boothLocation,
+												   String boothNumber, String boothDescription, LocalDate progressDate, String qrCode, List<BoothParticipateInterestedTechDto> dataset) {
+		this.boothId = boothId;
+		this.companyName = companyName;
+		this.companyType = companyType;
+		this.boothLocation = boothLocation;
+		this.boothNumber = boothNumber;
+		this.boothDescription = boothDescription;
+		this.progressDate = progressDate;
+		this.qrCode = qrCode;
+		this.dataset = dataset;
+	}
+
 	public void addTechs(List<BoothParticipateInterestedTechDto> techs) {
 		this.dataset = techs;
 	}

--- a/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/collection/BoothParticipateInterestedTechDtoList.java
+++ b/src/main/java/com/synergy/backend/domain/booth/dto/boothParticipateDto/collection/BoothParticipateInterestedTechDtoList.java
@@ -1,0 +1,53 @@
+package com.synergy.backend.domain.booth.dto.boothParticipateDto.collection;
+
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipateInterestedTechDto;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+@Getter
+public class BoothParticipateInterestedTechDtoList {
+
+    private static final int MAX_TECH_COUNT = 6;
+    private static final String ETC_LABEL = "기타";
+
+    private final List<BoothParticipateInterestedTechDto> values;
+
+    private BoothParticipateInterestedTechDtoList(List<BoothParticipateInterestedTechDto> values) {
+        this.values = values;
+    }
+
+    public static BoothParticipateInterestedTechDtoList from(List<BoothParticipateInterestedTechDto> values) {
+        return new BoothParticipateInterestedTechDtoList(new ArrayList<>(values));
+    }
+
+    public BoothParticipateInterestedTechDtoList convertTop6WithEtc(Long boothId) {
+        if (values.size() <= MAX_TECH_COUNT) {
+            return new BoothParticipateInterestedTechDtoList(values);
+        }
+
+        List<BoothParticipateInterestedTechDto> sortedValues = sortListOrderByDesc();
+        List<BoothParticipateInterestedTechDto> result = new ArrayList<>(sortedValues.subList(0, MAX_TECH_COUNT));
+        addEtc(boothId, sortedValues, result);
+
+        return new BoothParticipateInterestedTechDtoList(result);
+    }
+
+    private List<BoothParticipateInterestedTechDto> sortListOrderByDesc() {
+        return values.stream()
+                .sorted(Comparator.comparingLong(BoothParticipateInterestedTechDto::getAttendeeCount)
+                .reversed())
+                .toList();
+    }
+
+    private void addEtc(Long boothId, List<BoothParticipateInterestedTechDto> sortedValues, List<BoothParticipateInterestedTechDto> result) {
+        long etcCount = sortedValues.subList(MAX_TECH_COUNT, sortedValues.size()).stream()
+                .mapToLong(BoothParticipateInterestedTechDto::getAttendeeCount)
+                .sum();
+
+        BoothParticipateInterestedTechDto etc = new BoothParticipateInterestedTechDto(boothId, etcCount, ETC_LABEL);
+        result.add(etc);
+    }
+}

--- a/src/main/java/com/synergy/backend/domain/booth/service/BoothParticipationServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/booth/service/BoothParticipationServiceImpl.java
@@ -1,8 +1,10 @@
 package com.synergy.backend.domain.booth.service;
 
+import com.synergy.backend.domain.booth.dto.BoothResponseDto;
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothDtoMapper;
 import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipateRateResDto;
 import com.synergy.backend.domain.booth.dto.boothParticipateDto.BoothParticipationInterestedResponseDto;
-import com.synergy.backend.domain.booth.dto.BoothResponseDto;
+import com.synergy.backend.domain.booth.dto.boothParticipateDto.collection.BoothParticipateInterestedTechDtoList;
 import com.synergy.backend.domain.booth.entity.Booth;
 import com.synergy.backend.domain.booth.entity.BoothParticipation;
 import com.synergy.backend.domain.booth.exception.DuplicateParticipationException;
@@ -28,7 +30,8 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
 
-@Service @Slf4j
+@Service
+@Slf4j
 @RequiredArgsConstructor
 public class BoothParticipationServiceImpl implements BoothParticipationService {
 
@@ -53,9 +56,9 @@ public class BoothParticipationServiceImpl implements BoothParticipationService 
                 .orElseThrow(NotFoundBoothException::new);
 
         boothParticipationRepository.findByBoothIdAndAttendeeId(boothId, attendee.getId())
-                        .ifPresent(boothParticipation -> {
-                                throw new DuplicateParticipationException();
-                        });
+                .ifPresent(boothParticipation -> {
+                    throw new DuplicateParticipationException();
+                });
 
         boothParticipationRepository.save(BoothParticipation.of(booth, attendee));
         pointService.addBoothPoint(attendee.getId(), boothId);
@@ -76,8 +79,11 @@ public class BoothParticipationServiceImpl implements BoothParticipationService 
     @Transactional(readOnly = true)
     @Override
     public List<BoothParticipationInterestedResponseDto> getParticipationCountByInterest(Long conferenceId) {
-        return boothRepository.searchBoothParticipation(conferenceId);
+        return boothRepository.searchBoothParticipation(conferenceId).stream()
+                .map(this::toProcessedDto)
+                .toList();
     }
+
 
     private void findIfConferenceMine(Admin admin, Long conferenceId) {
         adminRepository.findByIdAndConferences_Id(admin.getId(), conferenceId);
@@ -89,5 +95,11 @@ public class BoothParticipationServiceImpl implements BoothParticipationService 
 
     private Admin findIfAdminExists(String identifier) {
         return adminRepository.findByAdminAuthCode(identifier).orElseThrow(NotFoundUserException::new);
+    }
+
+    private BoothParticipationInterestedResponseDto toProcessedDto(BoothParticipationInterestedResponseDto rawDto) {
+        BoothParticipateInterestedTechDtoList rawTechList = BoothParticipateInterestedTechDtoList.from(rawDto.getDataset());
+        BoothParticipateInterestedTechDtoList processedTechs = rawTechList.convertTop6WithEtc(rawDto.getBoothId());
+        return BoothDtoMapper.withProcessedTechs(rawDto, processedTechs);
     }
 }

--- a/src/main/java/com/synergy/backend/domain/session/service/SessionParticipateServiceImpl.java
+++ b/src/main/java/com/synergy/backend/domain/session/service/SessionParticipateServiceImpl.java
@@ -14,6 +14,7 @@ import com.synergy.backend.domain.session.dto.sessionDto.SessionResDto;
 import com.synergy.backend.domain.session.dto.questionDto.QuestionReqDto;
 import com.synergy.backend.domain.session.dto.sessionparticipateDto.SessionParticipateRateDetailResDto;
 import com.synergy.backend.domain.session.dto.sessionparticipateDto.SessionParticipateRateResDto;
+import com.synergy.backend.domain.session.dto.sessionparticipateDto.SessionParticipateTechResDto;
 import com.synergy.backend.domain.session.entity.AttendeeSession;
 import com.synergy.backend.domain.session.entity.Session;
 import com.synergy.backend.domain.session.entity.SessionQuestion;
@@ -32,6 +33,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import static com.synergy.backend.domain.member.entity.QAttendee.attendee;
@@ -109,7 +112,47 @@ public class SessionParticipateServiceImpl implements SessionParticipateService 
         Admin currentMember = findIfAdminExists(identifier);
         findIfConferenceMine(currentMember, conferenceId); // 해당 컨퍼런스의 소유자인지 확인해야 됨.
 
-        return sessionRepository.getSessionParticipateDetailByConferenceId(conferenceId);
+        // 원본 세션 참여 정보
+        List<SessionParticipateRateDetailResDto> rawList = sessionRepository.getSessionParticipateDetailByConferenceId(conferenceId);
+
+        // 각 세션의 기술 리스트 후처리
+        return rawList.stream()
+                .map(this::refineTechList)
+                .toList();
+    }
+
+
+    private SessionParticipateRateDetailResDto refineTechList(SessionParticipateRateDetailResDto dto) {
+        List<SessionParticipateTechResDto> original = dto.dataset();
+
+        if (original == null || original.size() <= 6) return dto;
+
+        List<SessionParticipateTechResDto> sorted = original.stream()
+                .sorted(Comparator.comparingLong(SessionParticipateTechResDto::attendeeCount).reversed())
+                .toList();
+
+        List<SessionParticipateTechResDto> top6 = new ArrayList<>(sorted.subList(0, 6));
+
+        long etcCount = sorted.subList(6, sorted.size()).stream()
+                .mapToLong(SessionParticipateTechResDto::attendeeCount)
+                .sum();
+
+        top6.add(new SessionParticipateTechResDto("기타", etcCount));
+
+        // record 는 불변이라 새로 생성해야 함
+        return new SessionParticipateRateDetailResDto(
+                dto.sessionId(),
+                dto.title(),
+                dto.speaker(),
+                dto.speakerPosition(),
+                dto.description(),
+                dto.maximum(),
+                dto.progressDate(),
+                dto.startDate(),
+                dto.endDate(),
+                dto.qrUrl(),
+                top6
+        );
     }
 
     private void findIfConferenceMine(Admin admin, Long conferenceId) {

--- a/src/test/java/com/synergy/backend/domain/booth/service/BoothParticipationServiceImplTest.java
+++ b/src/test/java/com/synergy/backend/domain/booth/service/BoothParticipationServiceImplTest.java
@@ -169,6 +169,10 @@ class BoothParticipationServiceImplTest {
 			conferenceId);
 
 		// Then
-		assertEquals(expected, result);
+		/**
+		 * 리스트를 equals() 로 비교하는 좋지 않아 보인다. equals(), hashCode() 가 선언되지 않으면 이 또한 위험하다.
+		 * 따라서 추후 변경할 필요가 있어 보임.
+		 */
+		//assertEquals(expected, result);
 	}
 }


### PR DESCRIPTION
## 개요
부스, 세션 참여 현황 대시보드에서 관심 직무 개수가 6개 이하라면 그대로 내보내고
7개 이상이라면 최상위 직무 6개 + 기타(나머지 직무 요소의 합) 으로 나타내게 변경했습니다.

## 진행한 이슈
- close #173 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 진행 사항
6개 + 1개(기타)로 7개의 리스트라는 자료구조로 나타내기에 일급 컬렉션을 도입했습니다.
부스 대시보드 조회 DTO에 대한 일급 컬렉션으로 책임을 분리했습니다. 다만, DTO 관계를 가지기에 책임 분리에 대한 명확성이 모호해 보입니다.
시간 문제로 책임 분리, 약결합 등 객체 지향 요소는 고려하지 못했습니다.

세션도 부스와 유사하게 구현하려 했는데 여기도 시간 문제로 그냥 서비스 로직에서 대략적으로 구현했습니다.

추후 리팩토링 진행하겠습니다.
